### PR TITLE
feat: implementa busca fuzzy combinada por nome da escola e município preservando filtros e paginação

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.8"
 services:
   api:
     build:
-      context: .
+      context: ./server
       dockerfile: Dockerfile
     container_name: api_service
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.8"
 services:
   api:
     build:
-      context: ./server
+      context: .
       dockerfile: Dockerfile
     container_name: api_service
     ports:

--- a/src/application/school/list_all_schools/list_all_schools.py
+++ b/src/application/school/list_all_schools/list_all_schools.py
@@ -4,10 +4,16 @@ from src.domain.value_objects.pagination import PaginatedResponse
 from src.application.common.base_list_use_case import BaseListUseCase
 from .list_all_schools_dto import ListSchoolsDTO
 
-
 class ListAllSchools(BaseListUseCase[School]):
     def __init__(self, school_repository: ISchoolRepository):
         super().__init__(school_repository)
+        self.school_repository = school_repository # Salvando a referência do repositório
 
     async def execute(self, dto: ListSchoolsDTO) -> PaginatedResponse[School]:
-        return await super().execute(dto.query)
+        # Aqui a mágica acontece: repassando os dados do DTO direto pra sua função do banco!
+        return await self.school_repository.list_all(
+            page=dto.query.page,
+            page_size=dto.query.page_size,
+            search_term=dto.search_term,
+            municipio=dto.municipio
+        )

--- a/src/application/school/list_all_schools/list_all_schools.py
+++ b/src/application/school/list_all_schools/list_all_schools.py
@@ -1,19 +1,35 @@
-from src.domain.repository.school_repository import ISchoolRepository
 from src.domain.entities.school import School
+from src.domain.repository.school_repository import ISchoolRepository
 from src.domain.value_objects.pagination import PaginatedResponse
-from src.application.common.base_list_use_case import BaseListUseCase
+from src.domain.value_objects.query import QueryFilter
+
 from .list_all_schools_dto import ListSchoolsDTO
 
-class ListAllSchools(BaseListUseCase[School]):
+
+class ListAllSchools:
     def __init__(self, school_repository: ISchoolRepository):
-        super().__init__(school_repository)
-        self.school_repository = school_repository # Salvando a referência do repositório
+        self.school_repository = school_repository
 
     async def execute(self, dto: ListSchoolsDTO) -> PaginatedResponse[School]:
-        # Aqui a mágica acontece: repassando os dados do DTO direto pra sua função do banco!
-        return await self.school_repository.list_all(
-            page=dto.query.page,
-            page_size=dto.query.page_size,
-            search_term=dto.search_term,
-            municipio=dto.municipio
-        )
+        filters = list(dto.query.filters or [])
+
+        if dto.search_term:
+            filters.append(
+                QueryFilter(
+                    field="escola_nome",
+                    operator="contains",
+                    value=dto.search_term,
+                )
+            )
+
+        if dto.municipio:
+            filters.append(
+                QueryFilter(
+                    field="municipio_nome",
+                    operator="contains",
+                    value=dto.municipio,
+                )
+            )
+
+        dto.query.filters = filters
+        return await self.school_repository.find_paginated(dto.query)

--- a/src/application/school/list_all_schools/list_all_schools_dto.py
+++ b/src/application/school/list_all_schools/list_all_schools_dto.py
@@ -1,8 +1,9 @@
 from dataclasses import dataclass
-
+from typing import Optional
 from src.domain.value_objects.query import QueryOptions
-
 
 @dataclass
 class ListSchoolsDTO:
     query: QueryOptions
+    search_term: Optional[str] = None
+    municipio: Optional[str] = None 

--- a/src/infrastructure/database/repository/mongo_school_repository.py
+++ b/src/infrastructure/database/repository/mongo_school_repository.py
@@ -6,7 +6,7 @@ from bson.errors import InvalidId
 from src.domain.entities.school import School
 from src.domain.repository.school_repository import ISchoolRepository
 from src.domain.value_objects.pagination import PaginatedResponse
-from src.domain.value_objects.query import QueryOptions, QuerySort
+from src.domain.value_objects.query import QueryOptions, QuerySort, QueryFilter
 from src.infrastructure.database.config.app_config import config
 from ..mapper.school_mapper import MongoSchoolMapper
 from .base_mongo_repository import BaseMongoRepository
@@ -80,11 +80,37 @@ class MongoSchoolRepository(BaseMongoRepository[School], ISchoolRepository):
         self,
         page: int,
         page_size: int,
+        search_term: str = None, 
+        municipio: str = None, # <-- Recebendo o novo parâmetro
     ) -> PaginatedResponse[School]:
+        
+        filters = []
+        
+        # Filtro da Escola (que você já fez)
+        if search_term:
+            filters.append(
+                QueryFilter(
+                    field="escola_nome", 
+                    operator="eq", 
+                    value={"$regex": f".*{search_term}.*", "$options": "i"}
+                )
+            )
+
+        # Filtro do Município (Exatamente a mesma lógica!)
+        if municipio:
+            filters.append(
+                QueryFilter(
+                    field="municipio_nome", 
+                    operator="eq", 
+                    value={"$regex": f".*{municipio}.*", "$options": "i"}
+                )
+            )
+
         query = QueryOptions(
             page=page,
             page_size=page_size,
             sort=QuerySort(field="escola_id_inep", direction=1),
+            filters=filters 
         )
         return await self.find_paginated(query)
 

--- a/src/infrastructure/database/repository/mongo_school_repository.py
+++ b/src/infrastructure/database/repository/mongo_school_repository.py
@@ -6,8 +6,9 @@ from bson.errors import InvalidId
 from src.domain.entities.school import School
 from src.domain.repository.school_repository import ISchoolRepository
 from src.domain.value_objects.pagination import PaginatedResponse
-from src.domain.value_objects.query import QueryOptions, QuerySort, QueryFilter
+from src.domain.value_objects.query import QueryOptions, QuerySort
 from src.infrastructure.database.config.app_config import config
+
 from ..mapper.school_mapper import MongoSchoolMapper
 from .base_mongo_repository import BaseMongoRepository
 
@@ -80,37 +81,11 @@ class MongoSchoolRepository(BaseMongoRepository[School], ISchoolRepository):
         self,
         page: int,
         page_size: int,
-        search_term: str = None, 
-        municipio: str = None, # <-- Recebendo o novo parâmetro
     ) -> PaginatedResponse[School]:
-        
-        filters = []
-        
-        # Filtro da Escola (que você já fez)
-        if search_term:
-            filters.append(
-                QueryFilter(
-                    field="escola_nome", 
-                    operator="eq", 
-                    value={"$regex": f".*{search_term}.*", "$options": "i"}
-                )
-            )
-
-        # Filtro do Município (Exatamente a mesma lógica!)
-        if municipio:
-            filters.append(
-                QueryFilter(
-                    field="municipio_nome", 
-                    operator="eq", 
-                    value={"$regex": f".*{municipio}.*", "$options": "i"}
-                )
-            )
-
         query = QueryOptions(
             page=page,
             page_size=page_size,
             sort=QuerySort(field="escola_id_inep", direction=1),
-            filters=filters 
         )
         return await self.find_paginated(query)
 

--- a/src/presentation/http/controller/school/list_all_schools_controller.py
+++ b/src/presentation/http/controller/school/list_all_schools_controller.py
@@ -33,6 +33,8 @@ class ListAllSchoolsController:
     async def handle(
         self,
         request: Request,
+        search_term: str | None = None, 
+        municipio: str | None = None, # <-- Recebendo o município aqui
     ):
         query = QueryParamParser.parse(
             query_params=request.query_params,
@@ -45,7 +47,11 @@ class ListAllSchoolsController:
 
         search_schema = SchoolSearchSchema.from_query_options(query)
 
-        dto = ListSchoolsDTO(query=search_schema.to_query_options())
+        dto = ListSchoolsDTO(
+            query=search_schema.to_query_options(),
+            search_term=search_term,
+            municipio=municipio # <-- Colocando na mochila
+        )
 
         return await self.list_all_schools_use_case.execute(dto=dto)
 
@@ -59,12 +65,14 @@ async def list_all_schools_endpoint(
     request: Request,
     page: int = Query(1, ge=1),
     page_size: int = Query(10, ge=1, le=config.max_page_size),
+    search: str | None = Query(None), 
+    municipio: str | None = Query(None), # <-- Capturando da URL
     list_all_schools_use_case: ListAllSchools = Depends(
         get_list_all_schools_use_case
     ),
 ):
 
-    cursor = request.query_params.get("cursor")
+    cursor = request.query_params.get("cursor") # <-- Consertado aqui
     offset = (page - 1) * page_size
     if not cursor and offset > config.max_offset_records:
         raise HTTPException(
@@ -77,8 +85,14 @@ async def list_all_schools_endpoint(
 
     controller = ListAllSchoolsController(list_all_schools_use_case)
 
-    result = await controller.handle(request=request)
+    # Passando ambos os termos para frente
+    result = await controller.handle(
+        request=request, 
+        search_term=search,
+        municipio=municipio
+    )
 
+    # O BENDITO RETURN AQUI EMBAIXO!
     return PaginatedSchoolResponse(
         schools=result.items,
         total_items=result.total_items,

--- a/src/presentation/http/controller/school/list_all_schools_controller.py
+++ b/src/presentation/http/controller/school/list_all_schools_controller.py
@@ -34,7 +34,7 @@ class ListAllSchoolsController:
         self,
         request: Request,
         search_term: str | None = None, 
-        municipio: str | None = None, # <-- Recebendo o município aqui
+        municipio: str | None = None, 
     ):
         query = QueryParamParser.parse(
             query_params=request.query_params,
@@ -50,7 +50,7 @@ class ListAllSchoolsController:
         dto = ListSchoolsDTO(
             query=search_schema.to_query_options(),
             search_term=search_term,
-            municipio=municipio # <-- Colocando na mochila
+            municipio=municipio 
         )
 
         return await self.list_all_schools_use_case.execute(dto=dto)
@@ -66,13 +66,13 @@ async def list_all_schools_endpoint(
     page: int = Query(1, ge=1),
     page_size: int = Query(10, ge=1, le=config.max_page_size),
     search: str | None = Query(None), 
-    municipio: str | None = Query(None), # <-- Capturando da URL
+    municipio: str | None = Query(None), 
     list_all_schools_use_case: ListAllSchools = Depends(
         get_list_all_schools_use_case
     ),
 ):
 
-    cursor = request.query_params.get("cursor") # <-- Consertado aqui
+    cursor = request.query_params.get("cursor") 
     offset = (page - 1) * page_size
     if not cursor and offset > config.max_offset_records:
         raise HTTPException(
@@ -85,14 +85,14 @@ async def list_all_schools_endpoint(
 
     controller = ListAllSchoolsController(list_all_schools_use_case)
 
-    # Passando ambos os termos para frente
+    
     result = await controller.handle(
         request=request, 
         search_term=search,
         municipio=municipio
     )
 
-    # O BENDITO RETURN AQUI EMBAIXO!
+    
     return PaginatedSchoolResponse(
         schools=result.items,
         total_items=result.total_items,

--- a/tests/test_school_route.py
+++ b/tests/test_school_route.py
@@ -2,6 +2,7 @@ import pytest
 import httpx
 
 from src.domain.value_objects.pagination import PaginatedResponse
+from src.domain.value_objects.query import QueryFilter
 from src.main import app
 from src.presentation.http.controller.school.callable.school_callable import (
     get_bairro_by_school_id_use_case,
@@ -18,13 +19,17 @@ from tests.factories import build_school
 
 
 class FakeListAllSchoolsUseCase:
+    def __init__(self):
+        self.received_dto = None
+
     async def execute(self, dto):
+        self.received_dto = dto
         return PaginatedResponse(
             items=[build_school()],
             total_items=1,
             page=dto.query.page,
             page_size=dto.query.page_size,
-            next_cursor=None,
+            next_cursor=dto.query.cursor,
         )
 
 
@@ -85,16 +90,13 @@ class FakeGetBairroBySchoolIdUseCase:
 
 @pytest.mark.asyncio
 async def test_school_list_route_returns_paginated_payload(monkeypatch):
-    async def fake_connect():
-        return True
-
-    async def fake_disconnect():
-        return None
+    async def fake_connect(): return True
+    async def fake_disconnect(): return None
 
     from src.infrastructure.database.config.connect_db import mongodb
-
     monkeypatch.setattr(mongodb, "connect", fake_connect)
     monkeypatch.setattr(mongodb, "disconnect", fake_disconnect)
+    
     app.dependency_overrides[get_list_all_schools_use_case] = lambda: FakeListAllSchoolsUseCase()
     app.dependency_overrides[get_school_by_id_use_case] = lambda: FakeGetSchoolByIdUseCase()
     app.dependency_overrides[get_paraiba_geojson_use_case] = lambda: FakeGetParaibaGeoJsonUseCase()
@@ -102,10 +104,7 @@ async def test_school_list_route_returns_paginated_payload(monkeypatch):
     app.dependency_overrides[get_bairro_by_school_id_use_case] = lambda: FakeGetBairroBySchoolIdUseCase()
 
     transport = httpx.ASGITransport(app=app)
-    async with httpx.AsyncClient(
-        transport=transport,
-        base_url="http://test"
-    ) as client:
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
         response = await client.get("/api/v1/all?page=1&page_size=1")
 
     app.dependency_overrides.clear()
@@ -121,16 +120,13 @@ async def test_school_list_route_returns_paginated_payload(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_school_list_route_rejects_deep_offset(monkeypatch):
-    async def fake_connect():
-        return True
-
-    async def fake_disconnect():
-        return None
+    async def fake_connect(): return True
+    async def fake_disconnect(): return None
 
     from src.infrastructure.database.config.connect_db import mongodb
-
     monkeypatch.setattr(mongodb, "connect", fake_connect)
     monkeypatch.setattr(mongodb, "disconnect", fake_disconnect)
+    
     app.dependency_overrides[get_list_all_schools_use_case] = lambda: FakeListAllSchoolsUseCase()
     app.dependency_overrides[get_school_by_id_use_case] = lambda: FakeGetSchoolByIdUseCase()
     app.dependency_overrides[get_paraiba_geojson_use_case] = lambda: FakeGetParaibaGeoJsonUseCase()
@@ -138,29 +134,22 @@ async def test_school_list_route_rejects_deep_offset(monkeypatch):
     app.dependency_overrides[get_bairro_by_school_id_use_case] = lambda: FakeGetBairroBySchoolIdUseCase()
 
     transport = httpx.ASGITransport(app=app)
-    async with httpx.AsyncClient(
-        transport=transport,
-        base_url="http://test"
-    ) as client:
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
         response = await client.get("/api/v1/all?page=999999&page_size=100")
 
     app.dependency_overrides.clear()
-
     assert response.status_code == 422
 
 
 @pytest.mark.asyncio
 async def test_school_list_route_rejects_unsupported_filter(monkeypatch):
-    async def fake_connect():
-        return True
-
-    async def fake_disconnect():
-        return None
+    async def fake_connect(): return True
+    async def fake_disconnect(): return None
 
     from src.infrastructure.database.config.connect_db import mongodb
-
     monkeypatch.setattr(mongodb, "connect", fake_connect)
     monkeypatch.setattr(mongodb, "disconnect", fake_disconnect)
+    
     app.dependency_overrides[get_list_all_schools_use_case] = lambda: FakeListAllSchoolsUseCase()
     app.dependency_overrides[get_school_by_id_use_case] = lambda: FakeGetSchoolByIdUseCase()
     app.dependency_overrides[get_paraiba_geojson_use_case] = lambda: FakeGetParaibaGeoJsonUseCase()
@@ -168,43 +157,32 @@ async def test_school_list_route_rejects_unsupported_filter(monkeypatch):
     app.dependency_overrides[get_bairro_by_school_id_use_case] = lambda: FakeGetBairroBySchoolIdUseCase()
 
     transport = httpx.ASGITransport(app=app)
-    async with httpx.AsyncClient(
-        transport=transport,
-        base_url="http://test"
-    ) as client:
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
         response = await client.get("/api/v1/schools?filter[hack]=1")
 
     app.dependency_overrides.clear()
-
     assert response.status_code == 422
 
 
 @pytest.mark.asyncio
 async def test_school_detail_route_returns_school_when_found(monkeypatch):
-    async def fake_connect():
-        return True
-
-    async def fake_disconnect():
-        return None
+    async def fake_connect(): return True
+    async def fake_disconnect(): return None
 
     from src.infrastructure.database.config.connect_db import mongodb
-
     monkeypatch.setattr(mongodb, "connect", fake_connect)
     monkeypatch.setattr(mongodb, "disconnect", fake_disconnect)
+    
     app.dependency_overrides[get_school_by_id_use_case] = lambda: FakeGetSchoolByIdUseCase()
     app.dependency_overrides[get_paraiba_geojson_use_case] = lambda: FakeGetParaibaGeoJsonUseCase()
     app.dependency_overrides[get_bairros_geojson_use_case] = lambda: FakeGetBairrosGeoJsonUseCase()
     app.dependency_overrides[get_bairro_by_school_id_use_case] = lambda: FakeGetBairroBySchoolIdUseCase()
 
     transport = httpx.ASGITransport(app=app)
-    async with httpx.AsyncClient(
-        transport=transport,
-        base_url="http://test"
-    ) as client:
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
         response = await client.get("/api/v1/68c8d9747e1b2e5af20f3cd9")
 
     app.dependency_overrides.clear()
-
     assert response.status_code == 200
     payload = response.json()
     assert payload["id"] == "68c8d9747e1b2e5af20f3cd9"
@@ -212,43 +190,32 @@ async def test_school_detail_route_returns_school_when_found(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_school_detail_route_returns_404_when_missing(monkeypatch):
-    async def fake_connect():
-        return True
-
-    async def fake_disconnect():
-        return None
+    async def fake_connect(): return True
+    async def fake_disconnect(): return None
 
     from src.infrastructure.database.config.connect_db import mongodb
-
     monkeypatch.setattr(mongodb, "connect", fake_connect)
     monkeypatch.setattr(mongodb, "disconnect", fake_disconnect)
+    
     app.dependency_overrides[get_school_by_id_use_case] = lambda: FakeGetSchoolByIdUseCase()
     app.dependency_overrides[get_paraiba_geojson_use_case] = lambda: FakeGetParaibaGeoJsonUseCase()
     app.dependency_overrides[get_bairros_geojson_use_case] = lambda: FakeGetBairrosGeoJsonUseCase()
     app.dependency_overrides[get_bairro_by_school_id_use_case] = lambda: FakeGetBairroBySchoolIdUseCase()
 
     transport = httpx.ASGITransport(app=app)
-    async with httpx.AsyncClient(
-        transport=transport,
-        base_url="http://test"
-    ) as client:
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
         response = await client.get("/api/v1/missing-id")
 
     app.dependency_overrides.clear()
-
     assert response.status_code == 404
 
 
 @pytest.mark.asyncio
 async def test_get_paraiba_geojson_route_returns_feature_collection(monkeypatch):
-    async def fake_connect():
-        return True
-
-    async def fake_disconnect():
-        return None
+    async def fake_connect(): return True
+    async def fake_disconnect(): return None
 
     from src.infrastructure.database.config.connect_db import mongodb
-
     monkeypatch.setattr(mongodb, "connect", fake_connect)
     monkeypatch.setattr(mongodb, "disconnect", fake_disconnect)
     app.dependency_overrides[get_paraiba_geojson_use_case] = lambda: FakeGetParaibaGeoJsonUseCase()
@@ -258,7 +225,6 @@ async def test_get_paraiba_geojson_route_returns_feature_collection(monkeypatch)
         response = await client.get("/api/v1/escolas/geojson/paraiba")
 
     app.dependency_overrides.clear()
-
     assert response.status_code == 200
     payload = response.json()
     assert payload["type"] == "FeatureCollection"
@@ -267,14 +233,10 @@ async def test_get_paraiba_geojson_route_returns_feature_collection(monkeypatch)
 
 @pytest.mark.asyncio
 async def test_get_bairros_geojson_route_returns_aggregated_geojson(monkeypatch):
-    async def fake_connect():
-        return True
-
-    async def fake_disconnect():
-        return None
+    async def fake_connect(): return True
+    async def fake_disconnect(): return None
 
     from src.infrastructure.database.config.connect_db import mongodb
-
     monkeypatch.setattr(mongodb, "connect", fake_connect)
     monkeypatch.setattr(mongodb, "disconnect", fake_disconnect)
     app.dependency_overrides[get_bairros_geojson_use_case] = lambda: FakeGetBairrosGeoJsonUseCase()
@@ -284,7 +246,6 @@ async def test_get_bairros_geojson_route_returns_aggregated_geojson(monkeypatch)
         response = await client.get("/api/v1/bairros/geojson/Joao%20Pessoa")
 
     app.dependency_overrides.clear()
-
     assert response.status_code == 200
     payload = response.json()
     assert payload["type"] == "FeatureCollection"
@@ -293,14 +254,10 @@ async def test_get_bairros_geojson_route_returns_aggregated_geojson(monkeypatch)
 
 @pytest.mark.asyncio
 async def test_get_bairro_by_school_id_route_returns_bairro(monkeypatch):
-    async def fake_connect():
-        return True
-
-    async def fake_disconnect():
-        return None
+    async def fake_connect(): return True
+    async def fake_disconnect(): return None
 
     from src.infrastructure.database.config.connect_db import mongodb
-
     monkeypatch.setattr(mongodb, "connect", fake_connect)
     monkeypatch.setattr(mongodb, "disconnect", fake_disconnect)
     app.dependency_overrides[get_bairro_by_school_id_use_case] = lambda: FakeGetBairroBySchoolIdUseCase()
@@ -310,7 +267,6 @@ async def test_get_bairro_by_school_id_route_returns_bairro(monkeypatch):
         response = await client.get("/api/v1/bairro/68c8d9747e1b2e5af20f3cd9")
 
     app.dependency_overrides.clear()
-
     assert response.status_code == 200
     payload = response.json()
     assert payload["bairro"] == "Centro"
@@ -318,14 +274,10 @@ async def test_get_bairro_by_school_id_route_returns_bairro(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_get_bairro_by_school_id_route_returns_404(monkeypatch):
-    async def fake_connect():
-        return True
-
-    async def fake_disconnect():
-        return None
+    async def fake_connect(): return True
+    async def fake_disconnect(): return None
 
     from src.infrastructure.database.config.connect_db import mongodb
-
     monkeypatch.setattr(mongodb, "connect", fake_connect)
     monkeypatch.setattr(mongodb, "disconnect", fake_disconnect)
     app.dependency_overrides[get_bairro_by_school_id_use_case] = lambda: FakeGetBairroBySchoolIdUseCase()
@@ -335,5 +287,117 @@ async def test_get_bairro_by_school_id_route_returns_404(monkeypatch):
         response = await client.get("/api/v1/bairro/missing-id")
 
     app.dependency_overrides.clear()
-
     assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_school_list_route_accepts_name_only_search(monkeypatch):
+    async def fake_connect(): return True
+    async def fake_disconnect(): return None
+
+    from src.infrastructure.database.config.connect_db import mongodb
+    monkeypatch.setattr(mongodb, "connect", fake_connect)
+    monkeypatch.setattr(mongodb, "disconnect", fake_disconnect)
+    
+    fake_use_case = FakeListAllSchoolsUseCase()
+    app.dependency_overrides[get_list_all_schools_use_case] = lambda: fake_use_case
+    app.dependency_overrides[get_school_by_id_use_case] = lambda: FakeGetSchoolByIdUseCase()
+    app.dependency_overrides[get_paraiba_geojson_use_case] = lambda: FakeGetParaibaGeoJsonUseCase()
+    app.dependency_overrides[get_bairros_geojson_use_case] = lambda: FakeGetBairrosGeoJsonUseCase()
+    app.dependency_overrides[get_bairro_by_school_id_use_case] = lambda: FakeGetBairroBySchoolIdUseCase()
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/api/v1/all?search=escola")
+
+    app.dependency_overrides.clear()
+    assert response.status_code == 200
+    assert fake_use_case.received_dto.search_term == "escola"
+    assert fake_use_case.received_dto.municipio is None
+
+
+@pytest.mark.asyncio
+async def test_school_list_route_accepts_municipio_only_search(monkeypatch):
+    async def fake_connect(): return True
+    async def fake_disconnect(): return None
+
+    from src.infrastructure.database.config.connect_db import mongodb
+    monkeypatch.setattr(mongodb, "connect", fake_connect)
+    monkeypatch.setattr(mongodb, "disconnect", fake_disconnect)
+    
+    fake_use_case = FakeListAllSchoolsUseCase()
+    app.dependency_overrides[get_list_all_schools_use_case] = lambda: fake_use_case
+    app.dependency_overrides[get_school_by_id_use_case] = lambda: FakeGetSchoolByIdUseCase()
+    app.dependency_overrides[get_paraiba_geojson_use_case] = lambda: FakeGetParaibaGeoJsonUseCase()
+    app.dependency_overrides[get_bairros_geojson_use_case] = lambda: FakeGetBairrosGeoJsonUseCase()
+    app.dependency_overrides[get_bairro_by_school_id_use_case] = lambda: FakeGetBairroBySchoolIdUseCase()
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/api/v1/all?municipio=Joao%20Pessoa")
+
+    app.dependency_overrides.clear()
+    assert response.status_code == 200
+    assert fake_use_case.received_dto.search_term is None
+    assert fake_use_case.received_dto.municipio == "Joao Pessoa"
+
+
+@pytest.mark.asyncio
+async def test_school_list_route_accepts_combined_search_and_municipio(monkeypatch):
+    async def fake_connect(): return True
+    async def fake_disconnect(): return None
+
+    from src.infrastructure.database.config.connect_db import mongodb
+    monkeypatch.setattr(mongodb, "connect", fake_connect)
+    monkeypatch.setattr(mongodb, "disconnect", fake_disconnect)
+    
+    fake_use_case = FakeListAllSchoolsUseCase()
+    app.dependency_overrides[get_list_all_schools_use_case] = lambda: fake_use_case
+    app.dependency_overrides[get_school_by_id_use_case] = lambda: FakeGetSchoolByIdUseCase()
+    app.dependency_overrides[get_paraiba_geojson_use_case] = lambda: FakeGetParaibaGeoJsonUseCase()
+    app.dependency_overrides[get_bairros_geojson_use_case] = lambda: FakeGetBairrosGeoJsonUseCase()
+    app.dependency_overrides[get_bairro_by_school_id_use_case] = lambda: FakeGetBairroBySchoolIdUseCase()
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/api/v1/all?search=estadual&municipio=Joao%20Pessoa")
+
+    app.dependency_overrides.clear()
+    assert response.status_code == 200
+    assert fake_use_case.received_dto.search_term == "estadual"
+    assert fake_use_case.received_dto.municipio == "Joao Pessoa"
+
+
+@pytest.mark.asyncio
+async def test_school_list_route_preserves_filters_and_cursor_with_search_params(monkeypatch):
+    async def fake_connect(): return True
+    async def fake_disconnect(): return None
+
+    from src.infrastructure.database.config.connect_db import mongodb
+    monkeypatch.setattr(mongodb, "connect", fake_connect)
+    monkeypatch.setattr(mongodb, "disconnect", fake_disconnect)
+    
+    fake_use_case = FakeListAllSchoolsUseCase()
+    app.dependency_overrides[get_list_all_schools_use_case] = lambda: fake_use_case
+    app.dependency_overrides[get_school_by_id_use_case] = lambda: FakeGetSchoolByIdUseCase()
+    app.dependency_overrides[get_paraiba_geojson_use_case] = lambda: FakeGetParaibaGeoJsonUseCase()
+    app.dependency_overrides[get_bairros_geojson_use_case] = lambda: FakeGetBairrosGeoJsonUseCase()
+    app.dependency_overrides[get_bairro_by_school_id_use_case] = lambda: FakeGetBairroBySchoolIdUseCase()
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get(
+            "/api/v1/all?search=centro&cursor=cursor-123&filter[bairro]=Centro&page=1&page_size=10"
+        )
+
+    app.dependency_overrides.clear()
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["page"] == 1
+    assert payload["page_size"] == 10
+    assert payload["next_cursor"] == "cursor-123"
+    assert "total_items" in payload
+    assert fake_use_case.received_dto.query.cursor == "cursor-123"
+    assert fake_use_case.received_dto.query.filters == [
+        QueryFilter(field="bairro", operator="eq", value="Centro")
+    ]

--- a/tests/unit/application/school/test_list_all_schools.py
+++ b/tests/unit/application/school/test_list_all_schools.py
@@ -1,0 +1,76 @@
+import pytest
+from unittest.mock import AsyncMock, Mock
+
+from src.application.school.list_all_schools.list_all_schools import ListAllSchools
+from src.application.school.list_all_schools.list_all_schools_dto import ListSchoolsDTO
+from src.domain.value_objects.pagination import PaginatedResponse
+from src.domain.value_objects.query import QueryFilter, QueryOptions, QuerySort
+
+
+@pytest.mark.asyncio
+async def test_execute_appends_fuzzy_filters_and_preserves_query_options():
+    repository = Mock()
+    repository.find_paginated = AsyncMock(
+        return_value=PaginatedResponse(
+            page=1,
+            page_size=10,
+            total_items=0,
+            items=[],
+            next_cursor="next-token",
+        )
+    )
+    use_case = ListAllSchools(school_repository=repository)
+    dto = ListSchoolsDTO(
+        query=QueryOptions(
+            page=2,
+            page_size=5,
+            cursor="cursor-token",
+            sort=QuerySort(field="municipio_nome", direction=-1),
+            fields=["escola_nome", "municipio_nome"],
+            filters=[QueryFilter(field="bairro", operator="eq", value="Centro")],
+        ),
+        search_term="estadual",
+        municipio="Joao Pessoa",
+    )
+
+    result = await use_case.execute(dto)
+
+    repository.find_paginated.assert_called_once()
+    forwarded_query = repository.find_paginated.await_args.args[0]
+    assert forwarded_query.page == 2
+    assert forwarded_query.page_size == 5
+    assert forwarded_query.cursor == "cursor-token"
+    assert forwarded_query.sort == QuerySort(field="municipio_nome", direction=-1)
+    assert forwarded_query.fields == ["escola_nome", "municipio_nome"]
+    assert forwarded_query.filters == [
+        QueryFilter(field="bairro", operator="eq", value="Centro"),
+        QueryFilter(field="escola_nome", operator="contains", value="estadual"),
+        QueryFilter(field="municipio_nome", operator="contains", value="Joao Pessoa"),
+    ]
+    assert result.next_cursor == "next-token"
+
+
+@pytest.mark.asyncio
+async def test_execute_keeps_existing_filters_when_optional_search_params_are_missing():
+    repository = Mock()
+    repository.find_paginated = AsyncMock(
+        return_value=PaginatedResponse(
+            page=1,
+            page_size=10,
+            total_items=0,
+            items=[],
+        )
+    )
+    use_case = ListAllSchools(school_repository=repository)
+    dto = ListSchoolsDTO(
+        query=QueryOptions(
+            filters=[QueryFilter(field="estado_sigla", operator="eq", value="PB")]
+        )
+    )
+
+    await use_case.execute(dto)
+
+    forwarded_query = repository.find_paginated.await_args.args[0]
+    assert forwarded_query.filters == [
+        QueryFilter(field="estado_sigla", operator="eq", value="PB")
+    ]


### PR DESCRIPTION
## 🎯 O que foi feito?
Nesta PR, evoluímos o sistema de buscas da API para suportar buscas parciais (Fuzzy Search com `$regex` e *case-insensitive*), permitindo filtrar as escolas de forma mais flexível. 

Agora é possível buscar escolas não apenas pelo nome, mas também cruzando a informação com o município, ou buscando apenas pelo município de forma isolada.

### 🛠️ Alterações realizadas:
- **Repository:** Adicionado filtro dinâmico no `mongo_school_repository.py` usando `QueryFilter` com `$regex` para os campos `escola_nome` e `municipio_nome`.
- **Controller:** Atualizada a rota `GET /schools` (`list_all_schools_controller.py`) para capturar o novo parâmetro opcional `municipio` pela URL e tratá-lo na função `handle`.
- **DTO & Use Case:** Adicionado o campo `municipio` no `ListSchoolsDTO` e mapeado no repasse de parâmetros dentro do caso de uso `list_all_schools.py`.

## 🧪 Como testar?
Você pode testar a nova funcionalidade das seguintes formas diretamente no Insomnia ou navegador:

1. **Busca apenas por Escola:**
   `GET /api/v1/all?search=Joana`
2. **Busca apenas por Município:**
   `GET /api/v1/all?municipio=Triunfo`
3. **Busca Combinada (Escola dentro do Município):**
   `GET /api/v1/all?search=Joana&municipio=Triunfo`

## 📸 prints:

<img width="1574" height="883" alt="print_fuzzy_search" src="https://github.com/user-attachments/assets/d8049962-facf-4219-be5d-4ee0c861aebb" />

<img width="1578" height="878" alt="print_fuzzy_search_dois" src="https://github.com/user-attachments/assets/0192e0fd-ed3b-49d5-aafb-0295c2050a57" />



Ajustei os pontos da review.

- preservei `filters`, `sort`, `fields` e `cursor`
- removi a dependência de `BaseListUseCase` nesse fluxo
- integrei `search` e `municipio` ao mecanismo genérico de filtros
- adicionei testes cobrindo os novos cenários
- removi o ajuste local do `docker-compose.yml` da PR

Validação executada:
- `poetry run pytest` -> `26 passed`



