### PR TITLE
feat: adiciona filtro por municipio_id na listagem de escolas

### DIFF
--- a/src/application/school/list_all_schools/list_all_schools.py
+++ b/src/application/school/list_all_schools/list_all_schools.py
@@ -31,5 +31,14 @@ class ListAllSchools:
                 )
             )
 
+        if dto.municipio_id:
+            filters.append(
+                QueryFilter(
+                    field="municipio_id_ibge",
+                    operator="eq",
+                    value=dto.municipio_id,
+                )
+            )
+
         dto.query.filters = filters
         return await self.school_repository.find_paginated(dto.query)

--- a/src/application/school/list_all_schools/list_all_schools_dto.py
+++ b/src/application/school/list_all_schools/list_all_schools_dto.py
@@ -2,8 +2,10 @@ from dataclasses import dataclass
 from typing import Optional
 from src.domain.value_objects.query import QueryOptions
 
+
 @dataclass
 class ListSchoolsDTO:
     query: QueryOptions
     search_term: Optional[str] = None
-    municipio: Optional[str] = None 
+    municipio: Optional[str] = None
+    municipio_id: Optional[str] = None

--- a/src/infrastructure/database/repository/mongo_school_repository.py
+++ b/src/infrastructure/database/repository/mongo_school_repository.py
@@ -8,7 +8,7 @@ from bson.errors import InvalidId
 from src.domain.entities.school import School
 from src.domain.repository.school_repository import ISchoolRepository
 from src.domain.value_objects.pagination import PaginatedResponse
-from src.domain.value_objects.query import QueryOptions, QuerySort
+from src.domain.value_objects.query import QueryFilter, QueryOptions, QuerySort
 from src.infrastructure.database.config.app_config import config
 
 from ..mapper.school_mapper import MongoSchoolMapper
@@ -166,6 +166,54 @@ class MongoSchoolRepository(BaseMongoRepository[School], ISchoolRepository):
 
     async def find_paginated(self, query: QueryOptions) -> PaginatedResponse[School]:
         return await super().find_paginated(query)
+
+    def _build_filters(self, filters: list[QueryFilter]) -> dict:
+        if not filters:
+            return {}
+
+        clauses: list[dict] = []
+        regular_filters: list[QueryFilter] = []
+
+        for item in filters:
+            if item.field != "municipio_id_ibge":
+                regular_filters.append(item)
+                continue
+
+            if item.operator == "eq":
+                municipio_values = self._build_municipio_id_values(str(item.value))
+            elif item.operator == "in":
+                municipio_values = []
+                for value in item.value:
+                    municipio_values.extend(self._build_municipio_id_values(str(value)))
+            else:
+                regular_filters.append(item)
+                continue
+
+            unique_values: list[str | int] = []
+            for value in municipio_values:
+                if value not in unique_values:
+                    unique_values.append(value)
+
+            clauses.append(
+                {
+                    "$or": [
+                        {"municipioIdIbge": {"$in": unique_values}},
+                        {"municipio_id_ibge": {"$in": unique_values}},
+                        {"co_municipio": {"$in": unique_values}},
+                        {"idIbge": {"$in": unique_values}},
+                    ]
+                }
+            )
+
+        regular_clause = super()._build_filters(regular_filters)
+        if regular_clause:
+            clauses.append(regular_clause)
+
+        if not clauses:
+            return {}
+        if len(clauses) == 1:
+            return clauses[0]
+        return {"$and": clauses}
 
     async def get_paraiba_geojson(self, municipio_id: str | None = None) -> dict:
         await self._ensure_geojson_indexes()

--- a/src/presentation/http/controller/school/list_all_schools_controller.py
+++ b/src/presentation/http/controller/school/list_all_schools_controller.py
@@ -33,8 +33,9 @@ class ListAllSchoolsController:
     async def handle(
         self,
         request: Request,
-        search_term: str | None = None, 
-        municipio: str | None = None, 
+        search_term: str | None = None,
+        municipio: str | None = None,
+        municipio_id: str | None = None,
     ):
         query = QueryParamParser.parse(
             query_params=request.query_params,
@@ -50,7 +51,8 @@ class ListAllSchoolsController:
         dto = ListSchoolsDTO(
             query=search_schema.to_query_options(),
             search_term=search_term,
-            municipio=municipio 
+            municipio=municipio,
+            municipio_id=municipio_id,
         )
 
         return await self.list_all_schools_use_case.execute(dto=dto)
@@ -65,14 +67,14 @@ async def list_all_schools_endpoint(
     request: Request,
     page: int = Query(1, ge=1),
     page_size: int = Query(10, ge=1, le=config.max_page_size),
-    search: str | None = Query(None), 
-    municipio: str | None = Query(None), 
+    search: str | None = Query(None),
+    municipio: str | None = Query(None),
+    municipio_id: str | None = Query(None),
     list_all_schools_use_case: ListAllSchools = Depends(
         get_list_all_schools_use_case
     ),
 ):
-
-    cursor = request.query_params.get("cursor") 
+    cursor = request.query_params.get("cursor")
     offset = (page - 1) * page_size
     if not cursor and offset > config.max_offset_records:
         raise HTTPException(
@@ -84,15 +86,12 @@ async def list_all_schools_endpoint(
         )
 
     controller = ListAllSchoolsController(list_all_schools_use_case)
-
-    
     result = await controller.handle(
-        request=request, 
+        request=request,
         search_term=search,
-        municipio=municipio
+        municipio=municipio,
+        municipio_id=municipio_id,
     )
-
-    
     return PaginatedSchoolResponse(
         schools=result.items,
         total_items=result.total_items,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+import sys
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+project_root_str = str(PROJECT_ROOT)
+
+if project_root_str not in sys.path:
+    sys.path.insert(0, project_root_str)

--- a/tests/test_mongo_school_repository.py
+++ b/tests/test_mongo_school_repository.py
@@ -53,6 +53,49 @@ async def test_repository_uses_count_documents_when_filters_exist():
 
 
 @pytest.mark.asyncio
+async def test_repository_filters_municipio_id_across_legacy_fields():
+    collection = FakeCollection([build_school_document("school-1")])
+    repository = MongoSchoolRepository(collection=collection)
+
+    query = QueryOptions(
+        page=1,
+        page_size=10,
+        filters=[QueryFilter(field="municipio_id_ibge", operator="eq", value="2516805")],
+    )
+
+    await repository.find_paginated(query)
+
+    assert collection.find_args is not None
+    mongo_query, _ = collection.find_args
+    assert "$or" in mongo_query
+    assert {"municipioIdIbge": {"$in": ["2516805", 2516805]}} in mongo_query["$or"]
+    assert {"co_municipio": {"$in": ["2516805", 2516805]}} in mongo_query["$or"]
+
+
+@pytest.mark.asyncio
+async def test_repository_combines_municipio_id_with_other_filters():
+    collection = FakeCollection([build_school_document("school-1")])
+    repository = MongoSchoolRepository(collection=collection)
+
+    query = QueryOptions(
+        page=1,
+        page_size=10,
+        filters=[
+            QueryFilter(field="bairro", operator="eq", value="Centro"),
+            QueryFilter(field="municipio_id_ibge", operator="eq", value="2516805"),
+        ],
+    )
+
+    await repository.find_paginated(query)
+
+    assert collection.find_args is not None
+    mongo_query, _ = collection.find_args
+    assert "$and" in mongo_query
+    assert {"endereco.bairro": "Centro"} in mongo_query["$and"]
+    assert any("$or" in clause for clause in mongo_query["$and"])
+
+
+@pytest.mark.asyncio
 async def test_repository_get_by_id_uses_object_id_when_possible():
     object_id = ObjectId("68c8d9747e1b2e5af20f3cd6")
     collection = FakeCollection([build_school_document(object_id)])

--- a/tests/test_school_route.py
+++ b/tests/test_school_route.py
@@ -383,6 +383,32 @@ async def test_school_list_route_accepts_municipio_only_search(monkeypatch):
     assert response.status_code == 200
     assert fake_use_case.received_dto.search_term is None
     assert fake_use_case.received_dto.municipio == "Joao Pessoa"
+    assert fake_use_case.received_dto.municipio_id is None
+
+
+@pytest.mark.asyncio
+async def test_school_list_route_accepts_municipio_id_filter(monkeypatch):
+    async def fake_connect(): return True
+    async def fake_disconnect(): return None
+
+    from src.infrastructure.database.config.connect_db import mongodb
+    monkeypatch.setattr(mongodb, "connect", fake_connect)
+    monkeypatch.setattr(mongodb, "disconnect", fake_disconnect)
+
+    fake_use_case = FakeListAllSchoolsUseCase()
+    app.dependency_overrides[get_list_all_schools_use_case] = lambda: fake_use_case
+    app.dependency_overrides[get_school_by_id_use_case] = lambda: FakeGetSchoolByIdUseCase()
+    app.dependency_overrides[get_paraiba_geojson_use_case] = lambda: FakeGetParaibaGeoJsonUseCase()
+    app.dependency_overrides[get_bairros_geojson_use_case] = lambda: FakeGetBairrosGeoJsonUseCase()
+    app.dependency_overrides[get_bairro_by_school_id_use_case] = lambda: FakeGetBairroBySchoolIdUseCase()
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/api/v1/schools?municipio_id=2500106")
+
+    app.dependency_overrides.clear()
+    assert response.status_code == 200
+    assert fake_use_case.received_dto.municipio_id == "2500106"
 
 
 @pytest.mark.asyncio
@@ -409,6 +435,7 @@ async def test_school_list_route_accepts_combined_search_and_municipio(monkeypat
     assert response.status_code == 200
     assert fake_use_case.received_dto.search_term == "estadual"
     assert fake_use_case.received_dto.municipio == "Joao Pessoa"
+    assert fake_use_case.received_dto.municipio_id is None
 
 
 @pytest.mark.asyncio
@@ -440,6 +467,41 @@ async def test_school_list_route_preserves_filters_and_cursor_with_search_params
     assert payload["page_size"] == 10
     assert payload["next_cursor"] == "cursor-123"
     assert "total_items" in payload
+    assert fake_use_case.received_dto.query.cursor == "cursor-123"
+    assert fake_use_case.received_dto.query.filters == [
+        QueryFilter(field="bairro", operator="eq", value="Centro")
+    ]
+
+
+@pytest.mark.asyncio
+async def test_school_list_route_preserves_filters_and_cursor_with_municipio_id(monkeypatch):
+    async def fake_connect(): return True
+    async def fake_disconnect(): return None
+
+    from src.infrastructure.database.config.connect_db import mongodb
+    monkeypatch.setattr(mongodb, "connect", fake_connect)
+    monkeypatch.setattr(mongodb, "disconnect", fake_disconnect)
+
+    fake_use_case = FakeListAllSchoolsUseCase()
+    app.dependency_overrides[get_list_all_schools_use_case] = lambda: fake_use_case
+    app.dependency_overrides[get_school_by_id_use_case] = lambda: FakeGetSchoolByIdUseCase()
+    app.dependency_overrides[get_paraiba_geojson_use_case] = lambda: FakeGetParaibaGeoJsonUseCase()
+    app.dependency_overrides[get_bairros_geojson_use_case] = lambda: FakeGetBairrosGeoJsonUseCase()
+    app.dependency_overrides[get_bairro_by_school_id_use_case] = lambda: FakeGetBairroBySchoolIdUseCase()
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get(
+            "/api/v1/schools?municipio_id=2500106&cursor=cursor-123&filter[bairro]=Centro&page=1&page_size=10"
+        )
+
+    app.dependency_overrides.clear()
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["page"] == 1
+    assert payload["page_size"] == 10
+    assert payload["next_cursor"] == "cursor-123"
+    assert fake_use_case.received_dto.municipio_id == "2500106"
     assert fake_use_case.received_dto.query.cursor == "cursor-123"
     assert fake_use_case.received_dto.query.filters == [
         QueryFilter(field="bairro", operator="eq", value="Centro")

--- a/tests/unit/application/school/test_list_all_schools.py
+++ b/tests/unit/application/school/test_list_all_schools.py
@@ -31,6 +31,7 @@ async def test_execute_appends_fuzzy_filters_and_preserves_query_options():
         ),
         search_term="estadual",
         municipio="Joao Pessoa",
+        municipio_id="2507507",
     )
 
     result = await use_case.execute(dto)
@@ -46,6 +47,7 @@ async def test_execute_appends_fuzzy_filters_and_preserves_query_options():
         QueryFilter(field="bairro", operator="eq", value="Centro"),
         QueryFilter(field="escola_nome", operator="contains", value="estadual"),
         QueryFilter(field="municipio_nome", operator="contains", value="Joao Pessoa"),
+        QueryFilter(field="municipio_id_ibge", operator="eq", value="2507507"),
     ]
     assert result.next_cursor == "next-token"
 


### PR DESCRIPTION
## Descrição

Este PR implementa o filtro por `municipio_id` na listagem de escolas para permitir que o frontend atualize o catálogo lateral com base no município selecionado no mapa.

A API agora aceita `municipio_id` na query string e, quando informado, retorna apenas as escolas daquele município. Quando o parâmetro não é enviado, a listagem continua funcionando normalmente. O comportamento também permanece compatível com busca por nome, paginação e cursor.

## Principais mudanças

- adição do parâmetro `municipio_id` no endpoint de listagem
- atualização do DTO e do use case para receber e repassar o novo filtro
- ajuste no repositório para filtrar por município considerando os campos reais/legados da base:
  - `municipioIdIbge`
  - `municipio_id_ibge`
  - `co_municipio`
  - `idIbge`
- atualização e criação de testes automatizados
- ajuste do ambiente de testes para o `pytest` resolver corretamente `src`

## Validação

### Testes executados

- `poetry run pytest tests/test_mongo_school_repository.py`
- `poetry run pytest tests/unit/application/school/test_list_all_schools.py tests/test_school_route.py`

### Resultado

- `11 passed`
- `18 passed`

### Validação manual

- teste via Insomnia com `municipio=triun` para identificar um `municipio_id_ibge` real
- teste com `municipio_id=2516805`
- resposta `200 OK` com retorno de escolas do município filtrado

### Tempo da requisição:

- 476ms

### Print:

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/3c189f8c-63b8-4aad-aced-712400a0919c" />

## Exemplo

```http
GET /api/v1/all?page=1&page_size=10&municipio_id=2516805



