### PR TITLE
Endpoint pegar por id inep

### DIFF
--- a/src/application/school/get_school_by_id/get_school_by_id.py
+++ b/src/application/school/get_school_by_id/get_school_by_id.py
@@ -9,4 +9,4 @@ class GetSchoolById:
         self.school_repository = school_repository
 
     async def execute(self, dto: GetSchoolByIdDTO) -> Optional[School]:
-        return await self.school_repository.get_by_id(dto.id)
+        return await self.school_repository.get_by_inep_id(dto.escola_id_inep)

--- a/src/application/school/get_school_by_id/get_school_by_id_dto.py
+++ b/src/application/school/get_school_by_id/get_school_by_id_dto.py
@@ -1,4 +1,5 @@
 from pydantic import BaseModel, Field
 
+
 class GetSchoolByIdDTO(BaseModel):
-    id: str = Field(..., description="Unique identifier of the school")
+    escola_id_inep: str = Field(..., description="Identificador INEP da escola")

--- a/src/domain/repository/school_repository.py
+++ b/src/domain/repository/school_repository.py
@@ -119,6 +119,13 @@ class ISchoolRepository(IBaseReadRepository[School], ABC):
         ...
 
     @abstractmethod
+    async def get_by_inep_id(self, inep_id: str | int) -> Optional[School]:
+        """
+        Retrieves a single school by its INEP identifier (`escolaIdInep`).
+        """
+        ...
+
+    @abstractmethod
     async def list_all(self, page: int, page_size: int) -> PaginatedResponse[School]:
         """
         Retrieves a paginated list of all schools.

--- a/src/infrastructure/database/repository/mongo_school_repository.py
+++ b/src/infrastructure/database/repository/mongo_school_repository.py
@@ -350,6 +350,30 @@ class MongoSchoolRepository(BaseMongoRepository[School], ISchoolRepository):
 
         return {"type": "FeatureCollection", "features": features}
 
+    async def get_by_inep_id(self, inep_id: str | int) -> School | None:
+        """
+        Return a School domain object by its INEP identifier (`escolaIdInep`).
+        """
+        candidates: list[dict] = []
+
+        if isinstance(inep_id, int):
+            candidates.append({"escolaIdInep": inep_id})
+            candidates.append({"escola_id_inep": inep_id})
+        else:
+            candidates.append({"escolaIdInep": inep_id})
+            candidates.append({"escola_id_inep": inep_id})
+            if str(inep_id).isdigit():
+                candidates.append({"escolaIdInep": int(inep_id)})
+                candidates.append({"escola_id_inep": int(inep_id)})
+
+        query = {"$or": candidates}
+
+        doc = await self.collection.find_one(query)
+        if not doc:
+            return None
+
+        return self.mapper_to_domain(doc)
+
     async def get_bairro_by_school_id(self, school_id: str) -> dict | None:
         candidates = [{"_id": school_id}]
 

--- a/src/presentation/http/controller/school/get_school_by_id_controller.py
+++ b/src/presentation/http/controller/school/get_school_by_id_controller.py
@@ -13,8 +13,8 @@ class GetSchoolByIdController:
     def __init__(self, get_school_by_id_use_case: GetSchoolById):
         self.get_school_by_id_use_case = get_school_by_id_use_case
 
-    async def handle(self, school_id: str) -> School:
-        dto = GetSchoolByIdDTO(id=school_id)
+    async def handle(self, escola_id_inep: str) -> School:
+        dto = GetSchoolByIdDTO(escola_id_inep=escola_id_inep)
 
         result = await self.get_school_by_id_use_case.execute(dto=dto)
 
@@ -27,15 +27,15 @@ class GetSchoolByIdController:
 router = APIRouter()
 
 
-@router.get("/{school_id}", response_model=School)
+@router.get("/{escola_id_inep}", response_model=School)
 async def get_school_by_id(
-    school_id: str = Path(..., description="The unique identifier of the school"),
+    escola_id_inep: str = Path(..., description="Identificador INEP da escola"),
     get_school_by_id_use_case: GetSchoolById = Depends(
         get_school_by_id_use_case
     ),
 ):
     controller = GetSchoolByIdController(get_school_by_id_use_case)
 
-    result = await controller.handle(school_id=school_id)
+    result = await controller.handle(escola_id_inep=escola_id_inep)
 
     return result


### PR DESCRIPTION
## What does this PR do?
This pull request refactors the logic for retrieving a school by its identifier to use the INEP identifier (`escola_id_inep`) instead of a generic school ID. The changes affect the data transfer object, repository interface and implementation, use case, controller, and the HTTP route. The main goal is to standardize and clarify the usage of the INEP identifier throughout the codebase.

**API and DTO Changes:**

* The `GetSchoolByIdDTO` now uses the `escola_id_inep` field instead of `id`, reflecting the INEP identifier as the primary key.
* The HTTP route and controller have been updated to accept and use `escola_id_inep` as a path parameter, ensuring a consistent API interface. [[1]](diffhunk://#diff-7139983a7002d6ba01046391985a25929d1fe933b42a5cb5d88255792492d2b1L30-R39) [[2]](diffhunk://#diff-7139983a7002d6ba01046391985a25929d1fe933b42a5cb5d88255792492d2b1L16-R17)

**Repository Layer Updates:**

* The repository interface (`ISchoolRepository`) adds a new `get_by_inep_id` method, and the MongoDB repository implements this method to retrieve schools by either string or integer INEP identifiers, handling multiple possible field names in the database. [[1]](diffhunk://#diff-bc26b160dcbedc47ec58e1689fc56aef8cdb35608819cbea46b24904bb309dcaR121-R127) [[2]](diffhunk://#diff-e4fdba0db71bd1284a89884a9fc8d36573e51322b9ad58acb22021f83b5530aeR353-R376)

**Use Case Logic:**

* The use case (`GetSchoolById`) now fetches schools using the INEP identifier via the new repository method, aligning business logic with the updated API and data model.

These changes ensure that all layers of the application consistently use the INEP identifier for retrieving school records, improving clarity and reducing ambiguity.

<img width="1039" height="802" alt="image" src="https://github.com/user-attachments/assets/941be9c5-c1bf-419a-9c4d-a8739c2336cb" />


## Task link in GitHub Issues:

HotFix-3

## Screenshots or GIFs (if applicable)

## Quality Checklist

- [ ] My code follows the best practices and architecture defined for the project.
- [ ] I have tested my changes locally and they work as expected.

### Pre-Submission Checklist

_Before opening this PR, please confirm you have completed the following steps:_

- [ ] I have read and filled out the sections above.
