### PR TITLE
Creates neighbourhood endpoint with fallback

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,3 +11,5 @@ COPY poetry.lock pyproject.toml ./
 RUN poetry install --no-interaction --no-ansi --no-root --only=main
 
 COPY . .
+
+CMD ["poetry", "run", "uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,3 @@ COPY poetry.lock pyproject.toml ./
 RUN poetry install --no-interaction --no-ansi --no-root --only=main
 
 COPY . .
-
-CMD ["poetry", "run", "uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,11 +3,11 @@ version: "3.8"
 services:
   api:
     build:
-      context: ./server
+      context: .
       dockerfile: Dockerfile
     container_name: api_service
     ports:
-      - "5000:5000"
+      - "8000:8000"
     env_file:
       - .env
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,11 +3,11 @@ version: "3.8"
 services:
   api:
     build:
-      context: .
+      context: ./server
       dockerfile: Dockerfile
     container_name: api_service
     ports:
-      - "8000:8000"
+      - "5000:5000"
     env_file:
       - .env
 

--- a/src/application/bairro/get_bairro_resumo/get_bairro_resumo.py
+++ b/src/application/bairro/get_bairro_resumo/get_bairro_resumo.py
@@ -1,0 +1,10 @@
+from .get_bairro_resumo_dto import GetBairroResumoDTO
+from src.domain.entities.bairro import BairroResumo
+from src.domain.repository.bairro_repository import IBairroRepository
+
+class GetBairroResumo:
+    def __init__(self, bairro_repository: IBairroRepository):
+        self.bairro_repository = bairro_repository
+
+    async def execute(self, dto: GetBairroResumoDTO) -> BairroResumo | None:
+        return await self.bairro_repository.get_resumo(dto.bairro_id)

--- a/src/application/bairro/get_bairro_resumo/get_bairro_resumo_dto.py
+++ b/src/application/bairro/get_bairro_resumo/get_bairro_resumo_dto.py
@@ -1,0 +1,4 @@
+from pydantic import BaseModel, Field
+
+class GetBairroResumoDTO(BaseModel):
+    bairro_id: str = Field(..., min_length=10, max_length=10)

--- a/src/domain/entities/bairro.py
+++ b/src/domain/entities/bairro.py
@@ -1,0 +1,31 @@
+from pydantic import BaseModel, ConfigDict, Field
+from .municipio import SocioeconomicoStats
+
+class BairroEducacaoStats(BaseModel):
+    """Estatísticas educacionais para granularidade de Bairro."""
+    model_config = ConfigDict(from_attributes=True)
+
+    totalEscolas: int | None = None
+    totalMatriculas: int | None = None
+    pctComBiblioteca: float | int | None = None
+    pctComInternet: float | int | None = None
+    pctComLabInformatica: float | int | None = None
+    pctSemAcessibilidade: float | int | None = None
+    mediaIdebAnosIniciais: float | None = None
+    mediaIdebAnosFinals: float | None = None
+
+class BairroResumo(BaseModel):
+    """Entidade consolidada para o painel lateral de bairros."""
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str = Field(..., description="ID de 10 dígitos (7 mun + 3 bairro)")
+    bairro: str = Field(..., description="Nome do bairro")
+    municipio: str = Field(..., description="Nome do município")
+    municipioIdIbge: str = Field(..., description="Código IBGE 7 dígitos")
+    sg_uf: str | None = Field(default=None)
+    
+    tem_bairro_oficial: bool = Field(default=True)
+    source: str = Field(default="bairros_indicadores")
+
+    educacao: BairroEducacaoStats = Field(default_factory=BairroEducacaoStats)
+    socioeconomico: SocioeconomicoStats = Field(default_factory=SocioeconomicoStats)

--- a/src/domain/repository/bairro_repository.py
+++ b/src/domain/repository/bairro_repository.py
@@ -1,0 +1,8 @@
+from abc import ABC, abstractmethod
+from src.domain.entities.bairro import BairroResumo
+
+class IBairroRepository(ABC):
+    @abstractmethod
+    async def get_resumo(self, bairro_id: str) -> BairroResumo | None:
+        """Busca o resumo do bairro com lógica de fallback integrada."""
+        pass

--- a/src/infrastructure/database/repository/mongo_bairro_repository.py
+++ b/src/infrastructure/database/repository/mongo_bairro_repository.py
@@ -1,0 +1,61 @@
+from typing import Any
+from src.domain.entities.bairro import BairroResumo, BairroEducacaoStats
+from src.domain.entities.municipio import SocioeconomicoStats
+from src.domain.repository.bairro_repository import IBairroRepository
+from src.infrastructure.database.mapper.mongo_neighborhood_mapper import MongoNeighborhoodMapper
+from .mongo_territorial_aggregation_repository import MongoTerritorialAggregationRepository
+
+class MongoBairroRepository(MongoTerritorialAggregationRepository, IBairroRepository):
+    def __init__(self, bairro_collection: Any, setor_collection: Any):
+        # Reutilizamos a base que lida com agregações complexas
+        super().__init__(None, bairro_collection, setor_collection)
+
+    async def get_resumo(self, bairro_id: str) -> BairroResumo | None:
+        # 1. Tenta buscar documento oficial (com flexibilidade no nome do campo)
+        query = {
+            "$or": [
+                {"cd_bairro": bairro_id},
+                {"cd_bairro_ibge": bairro_id}
+            ]
+        }
+        doc = await self.bairro_collection.find_one(query)
+        
+        if doc:
+            return self._map_to_resumo(doc, source="bairros_indicadores", oficial=True)
+
+        # 2. Fallback: Agregação por setores
+        fallback_docs = await self.setor_collection.aggregate([
+            {"$match": query}, # Usamos a mesma query flexível aqui!
+            {"$group": {
+                "_id": "$cd_bairro_ibge", # O _id do group pode ficar assim mesmo
+                "municipioIdIbge": {"$first": "$municipioIdIbge"},
+                "bairro": {"$first": "$bairro"},
+                "municipio": {"$first": "$municipio"},
+                "sg_uf": {"$first": "$sg_uf"},
+                "totalEscolas": {"$sum": "$educacao.totalEscolas"},
+                "totalMatriculas": {"$sum": "$educacao.totalMatriculas"},
+                "populacaoTotal": {"$sum": "$socioeconomico.populacao.total"},
+                "pctComInternet": {"$avg": "$educacao.pctComInternet"}
+            }}
+        ]).to_list(length=1)
+
+        if fallback_docs:
+            return self._map_to_resumo(fallback_docs[0], source="setor_indicadores", oficial=False)
+
+        return None
+
+    def _map_to_resumo(self, doc: dict, source: str, oficial: bool) -> BairroResumo:
+        mapped = MongoNeighborhoodMapper.from_doc(doc, source=source)
+        
+        # Construção manual para garantir a separação correta sugerida pelo líder
+        return BairroResumo(
+            id=mapped["cd_bairro_ibge"],
+            bairro=mapped["bairro"],
+            municipio=mapped["municipio"],
+            municipioIdIbge=mapped["municipioIdIbge"],
+            sg_uf=mapped["sg_uf"],
+            tem_bairro_oficial=oficial,
+            source=source,
+            educacao=BairroEducacaoStats.model_validate(doc.get("educacao", {})),
+            socioeconomico=SocioeconomicoStats.model_validate(doc.get("socioeconomico", {}))
+        )

--- a/src/infrastructure/database/repository/mongo_bairro_repository.py
+++ b/src/infrastructure/database/repository/mongo_bairro_repository.py
@@ -7,11 +7,9 @@ from .mongo_territorial_aggregation_repository import MongoTerritorialAggregatio
 
 class MongoBairroRepository(MongoTerritorialAggregationRepository, IBairroRepository):
     def __init__(self, bairro_collection: Any, setor_collection: Any):
-        # Reutilizamos a base que lida com agregações complexas
         super().__init__(None, bairro_collection, setor_collection)
 
     async def get_resumo(self, bairro_id: str) -> BairroResumo | None:
-        # 1. Tenta buscar documento oficial (com flexibilidade no nome do campo)
         query = {
             "$or": [
                 {"cd_bairro": bairro_id},
@@ -23,11 +21,10 @@ class MongoBairroRepository(MongoTerritorialAggregationRepository, IBairroReposi
         if doc:
             return self._map_to_resumo(doc, source="bairros_indicadores", oficial=True)
 
-        # 2. Fallback: Agregação por setores
         fallback_docs = await self.setor_collection.aggregate([
-            {"$match": query}, # Usamos a mesma query flexível aqui!
+            {"$match": query},
             {"$group": {
-                "_id": "$cd_bairro_ibge", # O _id do group pode ficar assim mesmo
+                "_id": "$cd_bairro_ibge",
                 "municipioIdIbge": {"$first": "$municipioIdIbge"},
                 "bairro": {"$first": "$bairro"},
                 "municipio": {"$first": "$municipio"},
@@ -47,7 +44,6 @@ class MongoBairroRepository(MongoTerritorialAggregationRepository, IBairroReposi
     def _map_to_resumo(self, doc: dict, source: str, oficial: bool) -> BairroResumo:
         mapped = MongoNeighborhoodMapper.from_doc(doc, source=source)
         
-        # Construção manual para garantir a separação correta sugerida pelo líder
         return BairroResumo(
             id=mapped["cd_bairro_ibge"],
             bairro=mapped["bairro"],

--- a/src/main.py
+++ b/src/main.py
@@ -21,6 +21,12 @@ from src.infrastructure.database.config.connect_db import mongodb
 from src.presentation.http.middleware.global_exception_handler import (
     register_global_exception_handlers,
 )
+from src.presentation.http.controller.bairro.container import (
+    bairro_container, 
+)
+from src.presentation.http.controller.bairro.index import (
+    router as bairro_controller,
+)
 from contextlib import asynccontextmanager
 from dotenv import load_dotenv
 
@@ -34,6 +40,10 @@ school_container.wire(modules=[
 
 municipio_container.wire(modules=[
     "src.presentation.http.controller.municipio.municipios_controller",
+])
+
+bairro_container.wire(modules=[
+    "src.presentation.http.controller.bairro.bairro_controller",
 ])
 
 aggregation_container.wire(modules=[
@@ -72,4 +82,5 @@ register_global_exception_handlers(app)
 
 app.include_router(municipio_controller, prefix="/api/v1", tags=["municipios"])
 app.include_router(school_controller, prefix="/api/v1", tags=["schools"])
+app.include_router(bairro_controller, prefix="/api/v1", tags=["bairros"])
 app.include_router(aggregation_controller, prefix="/api/v1", tags=["aggregations"])

--- a/src/presentation/http/controller/bairro/bairro_controller.py
+++ b/src/presentation/http/controller/bairro/bairro_controller.py
@@ -1,0 +1,29 @@
+from fastapi import APIRouter, Depends, HTTPException, Path, status
+from src.domain.entities.bairro import BairroResumo
+from src.application.bairro.get_bairro_resumo.get_bairro_resumo import GetBairroResumo
+from src.application.bairro.get_bairro_resumo.get_bairro_resumo_dto import GetBairroResumoDTO
+from .callable.bairro_callable import get_bairro_resumo_use_case
+
+router = APIRouter()
+
+@router.get(
+    "/bairros/{bairro_id}/resumo",
+    response_model=BairroResumo,
+    tags=["bairros"],
+    summary="Resumo de bairro",
+    description="Retorna indicadores de bairro com fallback para agregação de setores."
+)
+async def get_bairro_resumo(
+    bairro_id: str = Path(..., min_length=10, max_length=10, description="ID de 10 dígitos"),
+    use_case: GetBairroResumo = Depends(get_bairro_resumo_use_case)
+):
+    dto = GetBairroResumoDTO(bairro_id=bairro_id)
+    resumo = await use_case.execute(dto)
+
+    if not resumo:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Bairro não encontrado."
+        )
+
+    return resumo

--- a/src/presentation/http/controller/bairro/callable/bairro_callable.py
+++ b/src/presentation/http/controller/bairro/callable/bairro_callable.py
@@ -1,0 +1,5 @@
+from src.application.bairro.get_bairro_resumo.get_bairro_resumo import GetBairroResumo
+from ..container import bairro_container
+
+def get_bairro_resumo_use_case() -> GetBairroResumo:
+    return bairro_container.get_resumo_use_case()

--- a/src/presentation/http/controller/bairro/container.py
+++ b/src/presentation/http/controller/bairro/container.py
@@ -1,0 +1,18 @@
+from dependency_injector import containers, providers
+from src.infrastructure.database.config.connect_db import mongodb
+from src.infrastructure.database.repository.mongo_bairro_repository import MongoBairroRepository
+from src.application.bairro.get_bairro_resumo.get_bairro_resumo import GetBairroResumo
+
+class BairroContainer(containers.DeclarativeContainer):
+    repository = providers.Factory(
+        MongoBairroRepository,
+        bairro_collection=providers.Callable(mongodb.get_collection, "bairro_indicadores"),
+        setor_collection=providers.Callable(mongodb.get_collection, "setor_indicadores"),
+    )
+
+    get_resumo_use_case = providers.Singleton(
+        GetBairroResumo,
+        bairro_repository=repository,
+    )
+
+bairro_container = BairroContainer()

--- a/src/presentation/http/controller/bairro/index.py
+++ b/src/presentation/http/controller/bairro/index.py
@@ -1,0 +1,8 @@
+from fastapi import APIRouter
+
+from .bairro_controller import router as bairros_router
+
+router = APIRouter()
+router.include_router(bairros_router)
+
+__all__ = ["router"]


### PR DESCRIPTION
## What does this PR do?

This pull request introduces the `Bairro` module and implements the `GET /api/v1/bairros/{bairro_id}/resumo` endpoint to feed the side detail panel on the frontend map.

The most important changes are:

Documentation and Design:
- Created the `BairroResumo` entity in the domain layer using the composite pattern, ensuring the separation of concerns. 
- Implemented a specific `BairroEducacaoStats` object to exclude irrelevant fields (like `totalBairros`) that exist in the database but do not belong to the neighborhood domain, ensuring data consistency.
- Kept strict adherence to the project's repeatable module standard, fully isolating the Domain, Application (Use Case), Infrastructure (Repository), and Presentation (Controller/DI) layers.

Pipeline Implementation:
- Implemented the `MongoBairroRepository` with a robust fallback mechanism. The query first attempts to fetch the official neighborhood data from `bairros_indicadores` using either `cd_bairro` or `cd_bairro_ibge`.
- If the official boundary is not found, the repository automatically falls back to an `$aggregate` pipeline, grouping data from `setor_indicadores` to sum and average metrics (schools, enrollments, population) on-the-fly.
- Ensured the response correctly outputs the `source` and `tem_bairro_oficial` flags to provide proper context to the frontend.
- Wired the new controller and dependencies into the application lifecycle in `main.py`.

## Task link in GitHub Issues:

Fixes #34 — [View issue](https://github.com/UFPB-Squad-Team/odin-api/issues/34)

## Screenshots or GIFs (if applicable)

<img width="1420" height="954" alt="image" src="https://github.com/user-attachments/assets/7c6c753d-19c1-4ad6-8fa4-eb886b349400" />


## Quality Checklist

- [x] My code follows the best practices and architecture defined for the project.
- [x] I have tested my changes locally and they work as expected.

### Pre-Submission Checklist

_Before opening this PR, please confirm you have completed the following steps:_

- [x] I have read and filled out the sections above.