### PR TITLE
task: acrescenta dados no endpoint geojson de escolas

### DIFF
--- a/src/domain/entities/municipio.py
+++ b/src/domain/entities/municipio.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, computed_field
 
 
 class MunicipioCatalogItem(BaseModel):
@@ -112,38 +112,47 @@ class MunicipioResumo(BaseModel):
         description="Data source used to build this summary",
     )
 
+    @computed_field
     @property
     def total_escolas(self) -> int:
         return int(self.educacao.totalEscolas or 0)
 
+    @computed_field
     @property
     def total_matriculas(self) -> int:
         return int(self.educacao.totalMatriculas or 0)
 
+    @computed_field
     @property
     def total_alunos(self) -> int:
         return int(self.educacao.totalMatriculas or 0)
 
+    @computed_field
     @property
     def pct_com_biblioteca(self) -> float | None:
         return self.educacao.pctComBiblioteca
 
+    @computed_field
     @property
     def pct_com_internet(self) -> float | None:
         return self.educacao.pctComInternet
 
+    @computed_field
     @property
     def pct_com_lab_informatica(self) -> float | None:
         return self.educacao.pctComLabInformatica
 
+    @computed_field
     @property
     def pct_sem_acessibilidade(self) -> float | None:
         return self.educacao.pctSemAcessibilidade
 
+    @computed_field
     @property
     def mediaIdebAnosIniciais(self) -> float | None:
         return self.educacao.mediaIdebAnosIniciais
 
+    @computed_field
     @property
     def mediaIdebAnosFinals(self) -> float | None:
         return self.educacao.mediaIdebAnosFinals

--- a/src/infrastructure/database/repository/mongo_school_repository.py
+++ b/src/infrastructure/database/repository/mongo_school_repository.py
@@ -250,10 +250,13 @@ class MongoSchoolRepository(BaseMongoRepository[School], ISchoolRepository):
             "municipio_id_ibge": 1,
             "co_municipio": 1,
             "idIbge": 1,
+            "estadoSigla": 1,
+            "inep": 1,
+            "inse": 1,
             "endereco.bairro": 1,
             "dependenciaAdm": 1,
             "tipoLocalizacao": 1,
-            "indicadores.ideb": 1,
+            "indicadores": 1,
             "localizacao": 1,
         }
 
@@ -267,6 +270,14 @@ class MongoSchoolRepository(BaseMongoRepository[School], ISchoolRepository):
 
             feature_id = str(escola_id_inep)
             municipio_id_ibge = self._resolve_municipio_id_ibge(doc)
+            indicadores = dict(doc.get("indicadores") or {})
+            ano_referencia = indicadores.get("anoReferencia", 2025)
+            total_alunos = indicadores.get("totalAlunos", 0)
+            inse = indicadores.get("inse", doc.get("inse"))
+            indicadores["anoReferencia"] = ano_referencia
+            indicadores["totalAlunos"] = total_alunos
+            if inse is not None:
+                indicadores["inse"] = inse
 
             features.append(
                 {
@@ -277,6 +288,12 @@ class MongoSchoolRepository(BaseMongoRepository[School], ISchoolRepository):
                         "id": feature_id,
                         "escola_nome": doc.get("escolaNome"),
                         "escola_id_inep": escola_id_inep,
+                        "estado_sigla": doc.get("estadoSigla") or "PB",
+                        "inep": doc.get("inep"),
+                        "inse": inse,
+                        "indicadores": indicadores,
+                        "anoReferencia": ano_referencia,
+                        "totalAlunos": total_alunos,
                         "municipio_nome": doc.get("municipioNome"),
                         "municipioIdIbge": (
                             str(municipio_id_ibge)

--- a/src/presentation/http/schemas/geojson_schema.py
+++ b/src/presentation/http/schemas/geojson_schema.py
@@ -1,6 +1,6 @@
-from typing import Literal
+from typing import Any, Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class GeoJsonPointGeometry(BaseModel):
@@ -12,6 +12,12 @@ class ParaibaSchoolProperties(BaseModel):
     id: str | None = None
     escola_nome: str | None = None
     escola_id_inep: int | None = None
+    estado_sigla: str = "PB"
+    inep: int | str | None = None
+    inse: float | int | str | None = None
+    indicadores: dict[str, Any] = Field(default_factory=dict)
+    anoReferencia: int = 2025
+    totalAlunos: int = 0
     municipio_nome: str | None = None
     municipioIdIbge: str | None = None
     bairro: str | None = None

--- a/tests/test_mongo_school_repository.py
+++ b/tests/test_mongo_school_repository.py
@@ -187,10 +187,16 @@ async def test_get_paraiba_geojson_uses_escola_id_inep_as_feature_id():
             "escolaIdInep": 25033158,
             "municipioNome": "Agua Branca",
             "municipioIdIbge": "2500106",
+            "estadoSigla": "PB",
             "bairro": "Centro",
             "dependenciaAdm": "Municipal",
             "tipoLocalizacao": "Urbana",
-            "indicadores": {"ideb": 4.2},
+            "indicadores": {
+                "ideb": 4.2,
+                "inse": 5.8,
+                "anoReferencia": 2025,
+                "totalAlunos": 120,
+            },
             "localizacao": {"type": "Point", "coordinates": [-34.86, -7.12]},
         }
     ])
@@ -204,12 +210,49 @@ async def test_get_paraiba_geojson_uses_escola_id_inep_as_feature_id():
     assert "$or" not in query
     assert projection is not None
     assert projection["localizacao"] == 1
+    assert projection["estadoSigla"] == 1
+    assert projection["indicadores"] == 1
 
     feature = result["features"][0]
     assert feature["id"] == "25033158"
     assert feature["properties"]["id"] == "25033158"
     assert feature["properties"]["escola_id_inep"] == 25033158
+    assert feature["properties"]["estado_sigla"] == "PB"
+    assert feature["properties"]["inep"] is None
+    assert feature["properties"]["indicadores"]["inse"] == 5.8
+    assert feature["properties"]["indicadores"]["anoReferencia"] == 2025
+    assert feature["properties"]["indicadores"]["totalAlunos"] == 120
+    assert feature["properties"]["inse"] == 5.8
+    assert feature["properties"]["anoReferencia"] == 2025
+    assert feature["properties"]["totalAlunos"] == 120
     assert feature["properties"]["municipioIdIbge"] == "2500106"
+
+
+@pytest.mark.asyncio
+async def test_get_paraiba_geojson_uses_required_property_defaults():
+    collection = FakeCollection([
+        {
+            "_id": "mongo-id-1",
+            "escolaNome": "Escola A",
+            "escolaIdInep": 25033158,
+            "municipioNome": "Agua Branca",
+            "municipioIdIbge": "2500106",
+            "dependenciaAdm": "Municipal",
+            "tipoLocalizacao": "Urbana",
+            "localizacao": {"type": "Point", "coordinates": [-34.86, -7.12]},
+        }
+    ])
+    repository = MongoSchoolRepository(collection=collection)
+
+    result = await repository.get_paraiba_geojson()
+
+    properties = result["features"][0]["properties"]
+    assert properties["estado_sigla"] == "PB"
+    assert properties["inep"] is None
+    assert properties["inse"] is None
+    assert properties["indicadores"] == {"anoReferencia": 2025, "totalAlunos": 0}
+    assert properties["anoReferencia"] == 2025
+    assert properties["totalAlunos"] == 0
 
 
 @pytest.mark.asyncio

--- a/tests/test_municipio_route.py
+++ b/tests/test_municipio_route.py
@@ -1,7 +1,11 @@
 import httpx
 import pytest
 
-from src.domain.entities.municipio import MunicipioCatalogItem, MunicipioResumo
+from src.domain.entities.municipio import (
+    EducacaoStats,
+    MunicipioCatalogItem,
+    MunicipioResumo,
+)
 from src.main import app
 from src.presentation.http.controller.aggregation.callable.aggregation_callable import (
     get_city_aggregations_use_case,
@@ -41,14 +45,16 @@ class FakeGetMunicipioResumoUseCase:
                 municipioIdIbge="2507507",
                 municipio="João Pessoa",
                 sg_uf="PB",
-                total_escolas=412,
-                total_matriculas=98000,
                 total_bairros=64,
-                pct_com_biblioteca=62.3,
-                pct_com_internet=88.1,
-                pct_com_lab_informatica=45.2,
-                pct_sem_acessibilidade=31.0,
-                mediaIdebAnosIniciais=5.12,
+                educacao=EducacaoStats(
+                    totalEscolas=412,
+                    totalMatriculas=98000,
+                    pctComBiblioteca=62.3,
+                    pctComInternet=88.1,
+                    pctComLabInformatica=45.2,
+                    pctSemAcessibilidade=31.0,
+                    mediaIdebAnosIniciais=5.12,
+                ),
                 tem_bairros_oficiais=True,
                 source="municipio_indicadores",
             )

--- a/tests/test_school_route.py
+++ b/tests/test_school_route.py
@@ -35,10 +35,10 @@ class FakeListAllSchoolsUseCase:
 
 class FakeGetSchoolByIdUseCase:
     async def execute(self, dto: GetSchoolByIdDTO):
-        if dto.id == "missing-id":
+        if dto.escola_id_inep == "missing-id":
             return None
         school = build_school()
-        school.id = dto.id
+        school.id = dto.escola_id_inep
         return school
 
 
@@ -59,6 +59,16 @@ class FakeGetParaibaGeoJsonUseCase:
                         "id": "25033158",
                         "escola_nome": "EMEIF MAE IAIA",
                         "escola_id_inep": 25033158,
+                        "estado_sigla": "PB",
+                        "inep": None,
+                        "inse": 5.8,
+                        "indicadores": {
+                            "inse": 5.8,
+                            "anoReferencia": 2025,
+                            "totalAlunos": 120,
+                        },
+                        "anoReferencia": 2025,
+                        "totalAlunos": 120,
                         "municipio_nome": "Agua Branca",
                         "municipioIdIbge": "2500106",
                         "bairro": "GUALTERINA ALENCAR VIDAL",
@@ -245,6 +255,12 @@ async def test_get_paraiba_geojson_route_returns_feature_collection(monkeypatch)
     assert payload["type"] == "FeatureCollection"
     assert payload["features"][0]["id"] == "25033158"
     assert payload["features"][0]["properties"]["id"] == "25033158"
+    assert payload["features"][0]["properties"]["estado_sigla"] == "PB"
+    assert payload["features"][0]["properties"]["inep"] is None
+    assert payload["features"][0]["properties"]["inse"] == 5.8
+    assert payload["features"][0]["properties"]["indicadores"]["totalAlunos"] == 120
+    assert payload["features"][0]["properties"]["anoReferencia"] == 2025
+    assert payload["features"][0]["properties"]["totalAlunos"] == 120
     assert payload["features"][0]["properties"]["municipioIdIbge"] == "2500106"
     assert fake_use_case.last_municipio_id is None
 

--- a/tests/unit/application/school/test_get_school_by_id.py
+++ b/tests/unit/application/school/test_get_school_by_id.py
@@ -13,27 +13,27 @@ async def test_should_return_school_when_found():
     fake_school = Mock(spec=School) 
     
     # Configura o mock para retornar a escola falsa de forma assíncrona
-    mock_repository.get_by_id = AsyncMock(return_value=fake_school)
+    mock_repository.get_by_inep_id = AsyncMock(return_value=fake_school)
 
     use_case = GetSchoolById(school_repository=mock_repository)
-    dto = GetSchoolByIdDTO(id="123")
+    dto = GetSchoolByIdDTO(escola_id_inep="123")
 
     # Act (Ação)
     result = await use_case.execute(dto)
 
     # Assert (Verificação)
     assert result == fake_school
-    mock_repository.get_by_id.assert_called_once_with("123")
+    mock_repository.get_by_inep_id.assert_called_once_with("123")
 
 @pytest.mark.asyncio
 async def test_should_return_none_when_not_found():
     # Arrange
     mock_repository = Mock()
     # Configura o mock para retornar None (não achou no banco)
-    mock_repository.get_by_id = AsyncMock(return_value=None)
+    mock_repository.get_by_inep_id = AsyncMock(return_value=None)
 
     use_case = GetSchoolById(school_repository=mock_repository)
-    dto = GetSchoolByIdDTO(id="999")
+    dto = GetSchoolByIdDTO(escola_id_inep="999")
 
     # Act
     result = await use_case.execute(dto)

--- a/tests/unit/application/school/test_get_school_by_id.py
+++ b/tests/unit/application/school/test_get_school_by_id.py
@@ -1,42 +1,34 @@
 import pytest
 from unittest.mock import AsyncMock, Mock
+
 from src.application.school.get_school_by_id.get_school_by_id import GetSchoolById
 from src.application.school.get_school_by_id.get_school_by_id_dto import GetSchoolByIdDTO
 from src.domain.entities.school import School
 
+
 @pytest.mark.asyncio
 async def test_should_return_school_when_found():
-    # Arrange (Preparação)
     mock_repository = Mock()
-    
-    # Simulamos uma Escola falsa retornada pelo banco
-    fake_school = Mock(spec=School) 
-    
-    # Configura o mock para retornar a escola falsa de forma assíncrona
+    fake_school = Mock(spec=School)
     mock_repository.get_by_inep_id = AsyncMock(return_value=fake_school)
 
     use_case = GetSchoolById(school_repository=mock_repository)
     dto = GetSchoolByIdDTO(escola_id_inep="123")
 
-    # Act (Ação)
     result = await use_case.execute(dto)
 
-    # Assert (Verificação)
     assert result == fake_school
     mock_repository.get_by_inep_id.assert_called_once_with("123")
 
+
 @pytest.mark.asyncio
 async def test_should_return_none_when_not_found():
-    # Arrange
     mock_repository = Mock()
-    # Configura o mock para retornar None (não achou no banco)
     mock_repository.get_by_inep_id = AsyncMock(return_value=None)
 
     use_case = GetSchoolById(school_repository=mock_repository)
     dto = GetSchoolByIdDTO(escola_id_inep="999")
 
-    # Act
     result = await use_case.execute(dto)
 
-    # Assert
     assert result is None


### PR DESCRIPTION
## O que foi feito:

- Atualiza o GeoJSON de escolas da Paraíba para incluir novos metadados em `properties`.
- Adiciona os campos `estado_sigla`, `inep`, `inse`, `indicadores`, `anoReferencia` e `totalAlunos`.
- Ajusta a projeção do MongoDB para trazer os campos necessários.
- Atualiza o schema de resposta do endpoint `/api/v1/escolas/geojson/paraiba`.
- Adiciona/atualiza testes para validar os novos campos e os valores padrão.

## Validação:

Executado teste completo da suíte:

`python -m pytest`

Resultado:

`55 passed`

## Print:

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/dfacc13b-443a-4d87-84c5-6b819b7fdd9d" />

