### PR TITLE
feat(municipio): implement fuzzy search for list_municipios with acce…

### DIFF
--- a/src/application/municipio/list_municipios/list_municipios.py
+++ b/src/application/municipio/list_municipios/list_municipios.py
@@ -9,4 +9,7 @@ class ListMunicipios:
         self.municipio_repository = municipio_repository
 
     async def execute(self, dto: ListMunicipiosDTO) -> list[MunicipioCatalogItem]:
-        return await self.municipio_repository.list_municipios(sg_uf=dto.sg_uf)
+        return await self.municipio_repository.list_municipios(
+            sg_uf=dto.sg_uf,
+            term=dto.term)  
+    

--- a/src/application/municipio/list_municipios/list_municipios_dto.py
+++ b/src/application/municipio/list_municipios/list_municipios_dto.py
@@ -3,3 +3,4 @@ from pydantic import BaseModel, Field
 
 class ListMunicipiosDTO(BaseModel):
     sg_uf: str | None = Field(default=None, description="Optional UF filter")
+    term: str | None = Field(default=None, description="Termo para busca parcial pelo nome do município")

--- a/src/domain/repository/municipio_repository.py
+++ b/src/domain/repository/municipio_repository.py
@@ -8,6 +8,7 @@ class IMunicipioRepository(ABC):
     async def list_municipios(
         self,
         sg_uf: str | None = None,
+        term: str | None = None, 
     ) -> list[MunicipioCatalogItem]:
         ...
 

--- a/src/infrastructure/database/repository/mongo_municipio_repository.py
+++ b/src/infrastructure/database/repository/mongo_municipio_repository.py
@@ -1,3 +1,4 @@
+import re
 import unicodedata
 from typing import Any
 
@@ -25,22 +26,67 @@ class MongoMunicipioRepository(MongoTerritorialAggregationRepository, IMunicipio
     ):
         super().__init__(municipio_collection, bairro_collection, setor_collection)
 
+    def _build_accent_insensitive_regex(self, term: str) -> str:
+        """Limpa o termo e constrói um regex que ignora acentuação."""
+        term = term.strip()
+        
+        term_sem_acento = "".join(
+            c for c in unicodedata.normalize("NFD", term)
+            if unicodedata.category(c) != "Mn"
+        )
+        
+        replacements = {
+            'a': '[aáàãâä]',
+            'e': '[eéèêë]',
+            'i': '[iíìîï]',
+            'o': '[oóòõôö]',
+            'u': '[uúùûü]',
+            'c': '[cç]'
+        }
+        
+        pattern = ""
+        for char in term_sem_acento:
+            char_lower = char.lower()
+            if char_lower in replacements:
+                pattern += replacements[char_lower]
+            else:
+                pattern += re.escape(char)
+                
+        return pattern
+
     async def list_municipios(
         self,
         sg_uf: str | None = None,
+        term: str | None = None,
     ) -> list[MunicipioCatalogItem]:
         normalized_uf = sg_uf.upper() if sg_uf else None
 
         query: dict[str, Any] = {}
+        and_conditions = []
+
         if normalized_uf:
-            query = {
+            and_conditions.append({
                 "$or": [
                     {"sg_uf": normalized_uf},
                     {"uf": normalized_uf},
                     {"estado_sigla": normalized_uf},
                     {"estadoSigla": normalized_uf},
                 ]
-            }
+            })
+
+        if term and term.strip():
+            regex_pattern = self._build_accent_insensitive_regex(term)
+            and_conditions.append({
+                "$or": [
+                    {"nm_municipio": {"$regex": regex_pattern, "$options": "i"}},
+                    {"municipio": {"$regex": regex_pattern, "$options": "i"}},
+                    {"municipio_nome": {"$regex": regex_pattern, "$options": "i"}},
+                    {"municipioNome": {"$regex": regex_pattern, "$options": "i"}},
+                ]
+            })
+
+        if and_conditions:
+            query["$and"] = and_conditions
 
         projection = {
             "co_municipio": 1,

--- a/src/presentation/http/controller/municipio/municipios_controller.py
+++ b/src/presentation/http/controller/municipio/municipios_controller.py
@@ -34,9 +34,16 @@ async def list_municipios(
         max_length=2,
         description="Filtro opcional por UF, por exemplo PB.",
     ),
+    term: str | None = Query(
+        default=None,
+        description="Termo opcional para busca aproximada (fuzzy) pelo nome.",
+    ),
     use_case: ListMunicipios = Depends(get_list_municipios_use_case),
 ):
-    dto = ListMunicipiosDTO(sg_uf=sg_uf.upper() if sg_uf else None)
+    dto = ListMunicipiosDTO(
+        sg_uf=sg_uf.upper() if sg_uf else None, 
+        term=term
+    )
     return await use_case.execute(dto)
 
 


### PR DESCRIPTION
Esta task implementa o parâmetro opcional term no endpoint de listagem de municípios. O objetivo é permitir que usuários realizem buscas parciais por nome (ex: buscar "joao" e encontrar "João Pessoa"), melhorando a experiência de filtros e seletores no frontend sem a necessidade de carregar todos os dados de uma vez.

 Alterações Realizadas
A implementação seguiu os padrões de arquitetura do projeto, distribuindo as responsabilidades da seguinte forma:

Domain: Atualização da interface IMunicipioRepository para aceitar o parâmetro opcional term.

Application: * Atualização do ListMunicipiosDTO para incluir o campo de busca.

Ajuste no caso de uso ListMunicipios para repassar o termo ao repositório.

Infrastructure (MongoDB): * Implementação de um helper _build_accent_insensitive_regex para garantir que a busca ignore acentos (ex: a encontra ã, á, etc).

Uso de regex com a flag $options: "i" para garantir que a busca seja case-insensitive.

Utilização de condições $and para manter a compatibilidade com o filtro de sg_uf.

Presentation (API):

Exposição do parâmetro term como Query parameter na rota GET /municipios.

Integridade: Mantida a rota de resumo de município e todas as injeções de dependência originais.

 Como Testar
Certifique-se de que o ambiente está rodando: poetry run uvicorn src.main:app --reload.

Acesse o Swagger em http://localhost:8000/docs.

Teste de Busca por Nome: Execute o endpoint /municipios passando term=joao.

Resultado esperado: Retorno de "João Pessoa".

Teste Case & Accent Insensitive: Tente buscar por term=JOAO ou term=joã.

Resultado esperado: O sistema deve retornar os mesmos resultados ignorando as diferenças.

Teste Combinado: Filtre por sg_uf=PB e term=campina.

Resultado esperado: Retorno de "Campina Grande".

Regressão: Verifique se a rota /municipios/{municipio_id}/resumo continua funcionando normalmente.

Testes Automatizados: Execute poetry run pytest.

<img width="1402" height="618" alt="image" src="https://github.com/user-attachments/assets/c74d022f-83b7-4472-a319-d1efc46d5df7" />


<img width="1397" height="835" alt="image" src="https://github.com/user-attachments/assets/566cac49-fa8b-47d4-8aa5-ce730d682e6d" />
