### PR TITLE
Remove dupla chamada em container

### DIFF
--- a/src/presentation/http/controller/school/container.py
+++ b/src/presentation/http/controller/school/container.py
@@ -56,17 +56,3 @@ class Container(containers.DeclarativeContainer):
 
 container = Container()
 
-class Container(containers.DeclarativeContainer):
-    
-    stats_repository = providers.Factory(
-        MongoStatsRepository,
-        collection=providers.Callable(mongodb.get_collection, "escolas") 
-    )
-
-    
-    get_summary_stats_use_case = providers.Singleton(
-        GetSummaryStatsUseCase,
-        repository=stats_repository
-    )
-
-container = Container()


### PR DESCRIPTION
## What does this PR do?
This pull request removes the dependency injection container for the school stats controller, simplifying the codebase by eliminating unused or unnecessary provider definitions.

Dependency injection cleanup:

* Removed the `Container` class in `src/presentation/http/controller/school/container.py`, which included providers for `MongoStatsRepository` and `GetSummaryStatsUseCase`.

## Task link in GitHub Issues:
hotfix-3

## Screenshots or GIFs (if applicable)

## Quality Checklist

- [ ] My code follows the best practices and architecture defined for the project.
- [ ] I have tested my changes locally and they work as expected.

### Pre-Submission Checklist

_Before opening this PR, please confirm you have completed the following steps:_

- [ ] I have read and filled out the sections above.
