### PR TITLE
fix: preserve aggregation city indicator fields

### DIFF
--- a/src/infrastructure/database/repository/mongo_territorial_aggregation_repository.py
+++ b/src/infrastructure/database/repository/mongo_territorial_aggregation_repository.py
@@ -511,6 +511,8 @@ class MongoTerritorialAggregationRepository(
                     "pct_com_internet": {"$avg": "$pct_com_internet"},
                     "pct_com_lab_informatica": {"$avg": "$pct_com_lab_informatica"},
                     "pct_sem_acessibilidade": {"$avg": "$pct_sem_acessibilidade"},
+                    "socioeconomico": {"$first": "$socioeconomico"},
+                    "educacao": {"$first": "$educacao"},
                     "avg_lon": {"$avg": "$lon"},
                     "avg_lat": {"$avg": "$lat"},
                 }
@@ -528,6 +530,8 @@ class MongoTerritorialAggregationRepository(
                     "pct_com_internet": 1,
                     "pct_com_lab_informatica": 1,
                     "pct_sem_acessibilidade": 1,
+                    "socioeconomico": 1,
+                    "educacao": 1,
                     "avg_lon": 1,
                     "avg_lat": 1,
                 }

--- a/src/presentation/http/schemas/aggregation_schema.py
+++ b/src/presentation/http/schemas/aggregation_schema.py
@@ -3,6 +3,9 @@ from typing import Any, Literal
 from pydantic import AliasChoices, BaseModel, ConfigDict, Field
 
 
+INDICATOR_MODEL_CONFIG = ConfigDict(extra="allow")
+
+
 class AggregationPointGeometry(BaseModel):
     type: Literal["Point"]
     coordinates: tuple[float, float]
@@ -14,6 +17,8 @@ class AggregationGeometry(BaseModel):
 
 
 class SocioeconomicoPopulacao(BaseModel):
+    model_config = INDICATOR_MODEL_CONFIG
+
     total: int | None = None
     totalDomiciliosParticulares: int | None = None
     totalDomicilios: int | None = None
@@ -21,13 +26,18 @@ class SocioeconomicoPopulacao(BaseModel):
 
 
 class SocioeconomicoEstruturaEtaria(BaseModel):
+    model_config = INDICATOR_MODEL_CONFIG
+
     pctCriancas0a9: float | int | None = None
     pctIdosos60Mais: float | int | None = None
     pctJovens15a29: float | int | None = None
     pctAdultos30a59: float | int | None = None
+    razaoDependencia: float | int | None = None
 
 
 class SocioeconomicoRaca(BaseModel):
+    model_config = INDICATOR_MODEL_CONFIG
+
     pctPretaParda: float | int | None = None
     pctBranca: float | int | None = None
     pctIndigena: float | int | None = None
@@ -39,6 +49,8 @@ class SocioeconomicoGenero(BaseModel):
 
 
 class SocioeconomicoSaneamento(BaseModel):
+    model_config = INDICATOR_MODEL_CONFIG
+
     pctAguaRedeGeral: float | int | None = None
     pctAguaInadequada: float | int | None = None
     pctAguaNaoEncanada: float | int | None = None
@@ -50,17 +62,25 @@ class SocioeconomicoSaneamento(BaseModel):
 
 
 class SocioeconomicoEducacaoPopulacao(BaseModel):
+    model_config = INDICATOR_MODEL_CONFIG
+
     taxaAnalfabetismo15Mais: float | int | None = None
 
 
 class SocioeconomicoFamilia(BaseModel):
+    model_config = INDICATOR_MODEL_CONFIG
+
     pctResponsavelFeminino: float | int | None = None
 
 class SocioeconomicoMortalidade(BaseModel):
+    model_config = INDICATOR_MODEL_CONFIG
+
     totalObitosDomicilios: float | int | None = None
     obitosInfantis0a4: float | int | None = None
 
 class SocioeconomicoHabitacao(BaseModel):
+    model_config = INDICATOR_MODEL_CONFIG
+
     pctDomImprovisado: float | int | None = None
     pctDomSuperlotado: float | int | None = None
     pctDomUnipessoal: float | int | None = None
@@ -70,6 +90,8 @@ class SocioeconomicoHabitacao(BaseModel):
 
 
 class Socioeconomico(BaseModel):
+    model_config = INDICATOR_MODEL_CONFIG
+
     anoReferencia: int | None = None
     fonte: str | None = None
     populacao: SocioeconomicoPopulacao | None = None
@@ -84,9 +106,14 @@ class Socioeconomico(BaseModel):
 
 
 class EducacaoMunicipio(BaseModel):
+    model_config = INDICATOR_MODEL_CONFIG
+
     totalEscolas: int | None = None
     totalMatriculas: int | None = None
     totalBairros: int | None = None
+    mediaIdebAnosIniciais: float | int | None = None
+    mediaIdebAnosFinais: float | int | None = None
+    mediaIdebAnosFinals: float | int | None = None
     pctComInternet: float | int | None = None
     pctComBiblioteca: float | int | None = None
     pctComLabInformatica: float | int | None = None

--- a/tests/test_aggregation_route.py
+++ b/tests/test_aggregation_route.py
@@ -42,6 +42,17 @@ class FakeGetCityAggregationsUseCase:
                             "anoReferencia": 2022,
                             "fonte": "IBGE Censo Demografico 2022",
                             "populacao": {"total": 817511},
+                            "estruturaEtaria": {
+                                "pctCriancas0a9": 12.5,
+                                "pctIdosos60Mais": 15.1,
+                                "razaoDependencia": 44.2,
+                            },
+                        },
+                        "educacao": {
+                            "totalEscolas": 123,
+                            "totalMatriculas": 45678,
+                            "mediaIdebAnosIniciais": 5.7,
+                            "mediaIdebAnosFinais": 4.9,
                         },
                         "source": source,
                     },
@@ -122,6 +133,20 @@ async def test_get_city_aggregations_route_returns_200_and_feature_collection(mo
     assert payload["features"][0]["properties"]["source"] == "setor_indicadores"
     assert payload["features"][0]["geometry"]["coordinates"] == [-34.86, -7.12]
     assert payload["features"][0]["properties"]["socioeconomico"]["anoReferencia"] == 2022
+    assert (
+        payload["features"][0]["properties"]["socioeconomico"]["estruturaEtaria"][
+            "razaoDependencia"
+        ]
+        == 44.2
+    )
+    assert (
+        payload["features"][0]["properties"]["educacao"]["mediaIdebAnosIniciais"]
+        == 5.7
+    )
+    assert (
+        payload["features"][0]["properties"]["educacao"]["mediaIdebAnosFinais"]
+        == 4.9
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_mongo_territorial_aggregation_repository.py
+++ b/tests/test_mongo_territorial_aggregation_repository.py
@@ -65,10 +65,17 @@ async def test_get_cities_returns_primary_collection_when_available():
                 "anoReferencia": 2022,
                 "fonte": "IBGE Censo Demografico 2022",
                 "populacao": {"total": 1000},
+                "estruturaEtaria": {
+                    "pctCriancas0a9": 12.5,
+                    "pctIdosos60Mais": 15.1,
+                    "razaoDependencia": 44.2,
+                },
             },
             "educacao": {
                 "totalEscolas": 101,
                 "totalMatriculas": 51000,
+                "mediaIdebAnosIniciais": 5.7,
+                "mediaIdebAnosFinais": 4.9,
                 "pctComInternet": 98.5,
             },
         }
@@ -93,7 +100,13 @@ async def test_get_cities_returns_primary_collection_when_available():
     assert feature["properties"]["total_alunos"] == 51000
     assert feature["properties"]["pct_com_internet"] == 98.5
     assert feature["properties"]["socioeconomico"]["anoReferencia"] == 2022
+    assert (
+        feature["properties"]["socioeconomico"]["estruturaEtaria"]["razaoDependencia"]
+        == 44.2
+    )
     assert feature["properties"]["educacao"]["totalMatriculas"] == 51000
+    assert feature["properties"]["educacao"]["mediaIdebAnosIniciais"] == 5.7
+    assert feature["properties"]["educacao"]["mediaIdebAnosFinais"] == 4.9
     assert setor_collection.last_aggregate_pipeline is None
 
 
@@ -112,6 +125,16 @@ async def test_get_cities_uses_setor_fallback_when_primary_missing():
                 "avg_ideb": 4.9,
                 "avg_lon": -34.85,
                 "avg_lat": -7.11,
+                "socioeconomico": {
+                    "anoReferencia": 2022,
+                    "estruturaEtaria": {"razaoDependencia": 44.2},
+                },
+                "educacao": {
+                    "totalEscolas": 80,
+                    "totalMatriculas": 42000,
+                    "mediaIdebAnosIniciais": 5.7,
+                    "mediaIdebAnosFinais": 4.9,
+                },
             }
         ]
     )
@@ -128,6 +151,12 @@ async def test_get_cities_uses_setor_fallback_when_primary_missing():
     feature = result["features"][0]
     assert feature["properties"]["source"] == "setor_indicadores"
     assert feature["geometry"]["coordinates"] == [-34.85, -7.11]
+    assert (
+        feature["properties"]["socioeconomico"]["estruturaEtaria"]["razaoDependencia"]
+        == 44.2
+    )
+    assert feature["properties"]["educacao"]["mediaIdebAnosIniciais"] == 5.7
+    assert feature["properties"]["educacao"]["mediaIdebAnosFinais"] == 4.9
     assert setor_collection.last_aggregate_pipeline is not None
     assert {
         "$or": [
@@ -135,6 +164,12 @@ async def test_get_cities_uses_setor_fallback_when_primary_missing():
             {"municipioIdIbge": "2507507"},
         ]
     } in setor_collection.last_aggregate_pipeline[0]["$match"]["$and"]
+    group_stage = setor_collection.last_aggregate_pipeline[2]["$group"]
+    project_stage = setor_collection.last_aggregate_pipeline[3]["$project"]
+    assert group_stage["socioeconomico"] == {"$first": "$socioeconomico"}
+    assert group_stage["educacao"] == {"$first": "$educacao"}
+    assert project_stage["socioeconomico"] == 1
+    assert project_stage["educacao"] == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Resumo

Corrige a serialização do endpoint `GET /api/v1/aggregations/cities` para preservar campos aninhados de indicadores municipais em `properties.educacao` e `properties.socioeconomico`.

## O que esse PR faz

- Atualiza o schema de aggregations para preservar campos aninhados em `educacao` e `socioeconomico`.
- Adiciona suporte para `properties.educacao.mediaIdebAnosIniciais`.
- Adiciona suporte para `properties.educacao.mediaIdebAnosFinais`.
- Adiciona suporte para `properties.educacao.mediaIdebAnosFinals`.
- Adiciona suporte para `properties.socioeconomico.estruturaEtaria.razaoDependencia`.
- Permite que os blocos de indicadores aceitem campos extras, evitando que novas métricas aninhadas sejam removidas automaticamente.
- Ajusta o fallback via `setor_indicadores` para manter `educacao` e `socioeconomico` no resultado agregado por cidade.
- Adiciona testes cobrindo a resposta do endpoint e o fallback do repositório.

## Como validar

Comando executado para os testes relacionados ao endpoint e ao repositório:

`.\.venv\Scripts\python.exe -m pytest tests\test_aggregation_route.py tests\test_mongo_territorial_aggregation_repository.py`

Resultado:

`14 passed`

Comando executado para a suíte completa:

`.\.venv\Scripts\python.exe -m pytest`

Resultado:

`57 passed, 1 warning` (DeprecationWarning: `example` has been deprecated, please use `examples` instead
src/presentation/http/controller/state/get_state_summary_controller.py:14)

Requisição testada no Insomnia:

`GET http://127.0.0.1:8000/api/v1/aggregations/cities?municipioIdIbge=2507507`

## Prints:



<img width="1111" height="834" alt="image" src="https://github.com/user-attachments/assets/38a916e2-b0e8-4db1-b226-78a7b6da7885" />



<img width="1110" height="932" alt="image" src="https://github.com/user-attachments/assets/0e414520-df68-42aa-b5db-931e44f970ec" />