### PR TITLE
Preserva o censo no fallback

### DIFF
--- a/src/infrastructure/database/repository/mongo_territorial_aggregation_repository.py
+++ b/src/infrastructure/database/repository/mongo_territorial_aggregation_repository.py
@@ -799,18 +799,27 @@ class MongoTerritorialAggregationRepository(
                     "tem_bairro_official": {
                         "$ifNull": [
                             "$tem_bairro_official",
-                            {"$ifNull": ["$tem_bairro_oficial", True]},
+                            {"$ifNull": ["$tem_bairro_oficial", False]},
                         ]
                     },
-                    "bairro_oficial": {"$ifNull": ["$bairro", "$nm_bairro"]},
+                    "bairro_resolvido": {
+                        "$cond": {
+                            "if": {"$or": [{"$ne": ["$bairro", None]}, {"$ne": ["$nm_bairro", None]}]},
+                            "then": {"$ifNull": ["$bairro", "$nm_bairro"]},
+                            "else": {
+                                "$ifNull": [
+                                    "$nome_area",
+                                    {"$ifNull": ["$situacao", "Setor sem nome"]},
+                                ]
+                            },
+                        }
+                    },
                     "cd_setor": {
                         "$ifNull": [
                             "$cd_setor",
                             {"$ifNull": ["$co_setor", "$id_setor"]},
                         ]
                     },
-                    "nome_area": 1,
-                    "situacao": 1,
                     "total_escolas": {
                         "$ifNull": [
                             "$total_escolas",
@@ -994,32 +1003,6 @@ class MongoTerritorialAggregationRepository(
             },
             {
                 "$addFields": {
-                    "bairro_resolvido": {
-                        "$cond": {
-                            "if": "$tem_bairro_official",
-                            "then": "$bairro_oficial",
-                            "else": {
-                                "$ifNull": [
-                                    "$nome_area",
-                                    {"$ifNull": ["$situacao", "$bairro_oficial"]},
-                                ]
-                            },
-                        }
-                    }
-                }
-            },
-            {
-                "$match": {
-                    "$expr": {
-                        "$and": [
-                            {"$ne": ["$bairro_resolvido", None]},
-                            {"$ne": ["$bairro_resolvido", ""]},
-                        ]
-                    }
-                }
-            },
-            {
-                "$addFields": {
                     "has_geometria": {
                         "$cond": {
                             "if": {"$ne": ["$geometria", None]},
@@ -1049,38 +1032,15 @@ class MongoTerritorialAggregationRepository(
                 }
             )
 
+        # NÃO agrupar por bairro - retornar cada setor censitário separadamente
+        # Isso preserva a granularidade original dos dados do censo
         pipeline.extend(
             [
-                {
-                    "$group": {
-                        "_id": "$bairro_resolvido",
-                        "co_municipio": {"$first": "$co_municipio"},
-                        "bairro": {"$first": "$bairro_resolvido"},
-                        "cd_setor": {"$first": "$cd_setor"},
-                        "municipio": {"$first": "$municipio"},
-                        "uf": {"$first": "$uf"},
-                        "tem_bairro_official": {"$first": "$tem_bairro_official"},
-                        "total_escolas": {"$sum": "$total_escolas"},
-                        "total_alunos": {"$sum": "$total_alunos"},
-                        "avg_ideb": {"$avg": "$avg_ideb"},
-                        "pct_com_biblioteca": {"$avg": "$pct_com_biblioteca"},
-                        "pct_com_internet": {"$avg": "$pct_com_internet"},
-                        "pct_com_internet_alunos": {"$avg": "$pct_com_internet_alunos"},
-                        "pct_com_lab_informatica": {"$avg": "$pct_com_lab_informatica"},
-                        "pct_com_lab_ciencias": {"$avg": "$pct_com_lab_ciencias"},
-                        "pct_sem_acessibilidade": {"$avg": "$pct_sem_acessibilidade"},
-                        "geometria": {"$first": "$geometria"},
-                        "socioeconomico": {"$first": "$socioeconomico"},
-                        "educacao": {"$first": "$educacao"},
-                        "avg_lon": {"$avg": "$lon"},
-                        "avg_lat": {"$avg": "$lat"},
-                    }
-                },
                 {
                     "$project": {
                         "_id": 0,
                         "co_municipio": 1,
-                        "bairro": 1,
+                        "bairro": "$bairro_resolvido",
                         "cd_setor": 1,
                         "municipio": 1,
                         "uf": 1,
@@ -1097,12 +1057,36 @@ class MongoTerritorialAggregationRepository(
                         "geometria": 1,
                         "socioeconomico": 1,
                         "educacao": 1,
-                        "avg_lon": 1,
-                        "avg_lat": 1,
+                        "lon": 1,
+                        "lat": 1,
                     }
                 },
-                {"$sort": {"total_escolas": -1, "bairro": 1}},
+                {"$sort": {"bairro": 1, "cd_setor": 1}},
             ]
         )
+
+        pipeline.insert(-1, {
+            "$addFields": {
+                "educacao": {
+                    "$ifNull": [
+                        "$educacao",
+                        {
+                            "totalEscolas": "$total_escolas",
+                            "totalMatriculas": "$total_alunos",
+                            "pctComInternet": "$pct_com_internet",
+                            "pctComBiblioteca": "$pct_com_biblioteca",
+                            "pctComLaboratorioInformatica": "$pct_com_lab_informatica",
+                            "pctSemAcessibilidade": "$pct_sem_acessibilidade",
+                        }
+                    ]
+                },
+                "socioeconomico": {
+                    "$ifNull": [
+                        "$socioeconomico",
+                        {}
+                    ]
+                }
+            }
+        })
 
         return await self.setor_collection.aggregate(pipeline).to_list(length=None)

--- a/src/infrastructure/database/repository/mongo_territorial_aggregation_repository.py
+++ b/src/infrastructure/database/repository/mongo_territorial_aggregation_repository.py
@@ -804,7 +804,12 @@ class MongoTerritorialAggregationRepository(
                     },
                     "bairro_resolvido": {
                         "$cond": {
-                            "if": {"$or": [{"$ne": ["$bairro", None]}, {"$ne": ["$nm_bairro", None]}]},
+                            "if": {
+                                "$or": [
+                                    {"$ne": ["$bairro", None]},
+                                    {"$ne": ["$nm_bairro", None]},
+                                ]
+                            },
                             "then": {"$ifNull": ["$bairro", "$nm_bairro"]},
                             "else": {
                                 "$ifNull": [
@@ -1065,28 +1070,26 @@ class MongoTerritorialAggregationRepository(
             ]
         )
 
-        pipeline.insert(-1, {
-            "$addFields": {
-                "educacao": {
-                    "$ifNull": [
-                        "$educacao",
-                        {
-                            "totalEscolas": "$total_escolas",
-                            "totalMatriculas": "$total_alunos",
-                            "pctComInternet": "$pct_com_internet",
-                            "pctComBiblioteca": "$pct_com_biblioteca",
-                            "pctComLaboratorioInformatica": "$pct_com_lab_informatica",
-                            "pctSemAcessibilidade": "$pct_sem_acessibilidade",
-                        }
-                    ]
-                },
-                "socioeconomico": {
-                    "$ifNull": [
-                        "$socioeconomico",
-                        {}
-                    ]
+        pipeline.insert(
+            -1,
+            {
+                "$addFields": {
+                    "educacao": {
+                        "$ifNull": [
+                            "$educacao",
+                            {
+                                "totalEscolas": "$total_escolas",
+                                "totalMatriculas": "$total_alunos",
+                                "pctComInternet": "$pct_com_internet",
+                                "pctComBiblioteca": "$pct_com_biblioteca",
+                                "pctComLaboratorioInformatica": "$pct_com_lab_informatica",
+                                "pctSemAcessibilidade": "$pct_sem_acessibilidade",
+                            },
+                        ]
+                    },
+                    "socioeconomico": {"$ifNull": ["$socioeconomico", {}]},
                 }
-            }
-        })
+            },
+        )
 
         return await self.setor_collection.aggregate(pipeline).to_list(length=None)

--- a/src/presentation/http/controller/aggregation/aggregations_controller.py
+++ b/src/presentation/http/controller/aggregation/aggregations_controller.py
@@ -40,6 +40,15 @@ def _to_neighborhood_feature_collection(
             "setor" if item.get("source") == "setor_indicadores" else "bairro"
         )
 
+        if nivel == "setor":
+            cd_setor = item.get("cd_setor")
+            if cd_setor:
+                data_quality_label = f"Setor censitário {cd_setor} (agregação IBGE)"
+            else:
+                data_quality_label = "Setor censitário (agregação IBGE)"
+        else:
+            data_quality_label = "Dados de bairro oficial"
+
         properties: dict[str, Any] = {
             "id": str(resolved_id),
             "municipioIdIbge": str(item.get("municipioIdIbge", "")),
@@ -57,6 +66,7 @@ def _to_neighborhood_feature_collection(
             "pct_sem_acessibilidade": item.get("pct_sem_acessibilidade"),
             "tem_bairro_oficial": bool(item.get("tem_bairro_oficial", True)),
             "nivel": nivel,
+            "data_quality_label": data_quality_label,
             "socioeconomico": item.get("socioeconomico"),
             "educacao": item.get("educacao"),
             "source": str(item.get("source", "")),

--- a/src/presentation/http/schemas/aggregation_schema.py
+++ b/src/presentation/http/schemas/aggregation_schema.py
@@ -204,6 +204,7 @@ class MongoNeighborhoodAggregation(BaseModel):
         validation_alias=AliasChoices("tem_bairro_oficial", "tem_bairro_official"),
     )
     nivel: Literal["bairro", "setor"] = "bairro"
+    data_quality_label: str | None = None
     cd_setor: str | None = None
     socioeconomico: Socioeconomico | None = None
     educacao: EducacaoMunicipio | None = None
@@ -228,6 +229,7 @@ class NeighborhoodAggregationProperties(BaseModel):
     pct_sem_acessibilidade: float | int | None = None
     tem_bairro_oficial: bool = Field(serialization_alias="tem_bairro_oficial")
     nivel: Literal["bairro", "setor"] = "bairro"
+    data_quality_label: str | None = None
     cd_setor: str | None = None
     socioeconomico: Socioeconomico | None = None
     educacao: EducacaoMunicipio | None = None


### PR DESCRIPTION
## What does this PR do?

Additional changes:

- Fixed default value of `tem_bairro_oficial` from `True` to `False` to correct fallback logic for official neighborhood presence

- Moved `bairro_resolvido` calculation to the initial projection stage (replacing the old `bairro_oficial` field), removing redundant 
later `$addFields` and `$match` stages that filtered out records with empty neighborhood values

- Removed unused `nome_area` and `situacao` fields from the final projection as they are only used for neighborhood resolution logic

## Task link in GitHub Issues:

Fix-Setor

## Screenshots or GIFs (if applicable)

## Quality Checklist

- [ ] My code follows the best practices and architecture defined for the project.
- [ ] I have tested my changes locally and they work as expected.

### Pre-Submission Checklist

_Before opening this PR, please confirm you have completed the following steps:_

- [ ] I have read and filled out the sections above.
