### PR TITLE
[ODIN-B02] Atualiza agregações para suportar múltiplas UFs

### DIFF
--- a/src/application/aggregation/get_city_aggregations.py
+++ b/src/application/aggregation/get_city_aggregations.py
@@ -12,7 +12,7 @@ class GetCityAggregations:
     async def execute(
         self,
         co_municipio: str | None = None,
-        sg_uf: str | None = None,
+        sg_uf: str | list[str] | None = None,
         include_geometria: bool = False,
     ) -> dict[str, Any]:
         return await self.repository.get_cities(

--- a/src/application/aggregation/get_neighborhood_aggregations.py
+++ b/src/application/aggregation/get_neighborhood_aggregations.py
@@ -15,10 +15,12 @@ class GetNeighborhoodAggregations:
         municipio_id_ibge: str,
         bairro: str | None = None,
         include_geometria: bool = False,
+        sg_uf: str | list[str] | None = None,
     ) -> list[dict[str, Any]]:
         NeighborhoodValidator(municipio_id_ibge)
         return await self.repository.get_by_municipio(
             municipio_id_ibge=municipio_id_ibge,
             bairro=bairro,
+            sg_uf=sg_uf,
             include_geometria=include_geometria,
         )

--- a/src/domain/repository/territorial_aggregation_repository.py
+++ b/src/domain/repository/territorial_aggregation_repository.py
@@ -7,7 +7,7 @@ class ITerritorialAggregationRepository(ABC):
     async def get_cities(
         self,
         co_municipio: str | None = None,
-        sg_uf: str | None = None,
+        sg_uf: str | list[str] | None = None,
         include_geometria: bool = False,
     ) -> dict[str, Any]:
         """Returns consolidated city aggregates as GeoJSON FeatureCollection."""
@@ -19,6 +19,7 @@ class ITerritorialAggregationRepository(ABC):
         municipio_id_ibge: str,
         bairro: str | None = None,
         include_geometria: bool = False,
+        sg_uf: str | list[str] | None = None,
     ) -> list[dict[str, Any]]:
         """Returns neighborhood documents for a municipality using bairro_indicadores as primary source, including cd_municipio-compatible documents."""
         ...

--- a/src/infrastructure/database/repository/mongo_territorial_aggregation_repository.py
+++ b/src/infrastructure/database/repository/mongo_territorial_aggregation_repository.py
@@ -29,13 +29,41 @@ class MongoTerritorialAggregationRepository(
         self.bairro_collection = bairro_collection
         self.setor_collection = setor_collection
 
+    @staticmethod
+    def _normalize_uf_filter(
+        sg_uf: str | list[str] | None,
+    ) -> str | list[str] | None:
+        if isinstance(sg_uf, str):
+            normalized = sg_uf.strip().upper()
+            return normalized or None
+
+        if not sg_uf:
+            return None
+
+        normalized_ufs = list(
+            dict.fromkeys(uf.strip().upper() for uf in sg_uf if uf.strip())
+        )
+        return normalized_ufs or None
+
+    @staticmethod
+    def _uf_clause(sg_uf: str | list[str]) -> dict[str, Any]:
+        value: str | dict[str, list[str]]
+        value = {"$in": sg_uf} if isinstance(sg_uf, list) else sg_uf
+        return {
+            "$or": [
+                {"sg_uf": value},
+                {"uf": value},
+                {"estado_sigla": value},
+            ]
+        }
+
     async def get_cities(
         self,
         co_municipio: str | None = None,
-        sg_uf: str | None = None,
+        sg_uf: str | list[str] | None = None,
         include_geometria: bool = False,
     ) -> dict[str, Any]:
-        normalized_uf = sg_uf.upper() if sg_uf else None
+        normalized_uf = self._normalize_uf_filter(sg_uf)
 
         if co_municipio:
             query: dict[str, Any] = {
@@ -50,13 +78,7 @@ class MongoTerritorialAggregationRepository(
                 query = {
                     "$and": [
                         query,
-                        {
-                            "$or": [
-                                {"sg_uf": normalized_uf},
-                                {"uf": normalized_uf},
-                                {"estado_sigla": normalized_uf},
-                            ]
-                        },
+                        self._uf_clause(normalized_uf),
                     ]
                 }
 
@@ -96,13 +118,7 @@ class MongoTerritorialAggregationRepository(
 
         list_query: dict[str, Any] = {}
         if normalized_uf:
-            list_query = {
-                "$or": [
-                    {"sg_uf": normalized_uf},
-                    {"uf": normalized_uf},
-                    {"estado_sigla": normalized_uf},
-                ]
-            }
+            list_query = self._uf_clause(normalized_uf)
 
         docs = await self.municipio_collection.find(list_query).to_list(length=None)
         cities = [
@@ -126,10 +142,13 @@ class MongoTerritorialAggregationRepository(
         municipio_id_ibge: str,
         bairro: str | None = None,
         include_geometria: bool = False,
+        sg_uf: str | list[str] | None = None,
     ) -> list[dict[str, Any]]:
+        normalized_uf = self._normalize_uf_filter(sg_uf)
         primary_docs = await self._find_neighborhood_docs(
             municipio_id_ibge=municipio_id_ibge,
             bairro=bairro,
+            sg_uf=normalized_uf,
         )
 
         if primary_docs:
@@ -146,6 +165,7 @@ class MongoTerritorialAggregationRepository(
         fallback_docs = await self._aggregate_neighborhoods_from_setor(
             co_municipio=municipio_id_ibge,
             bairro=bairro,
+            sg_uf=normalized_uf,
         )
         return [
             MongoNeighborhoodMapper.from_doc(
@@ -531,6 +551,7 @@ class MongoTerritorialAggregationRepository(
         *,
         municipio_id_ibge: str,
         bairro: str | None = None,
+        sg_uf: str | list[str] | None = None,
     ) -> list[dict[str, Any]]:
         query: dict[str, Any] = {
             "$and": [
@@ -545,6 +566,9 @@ class MongoTerritorialAggregationRepository(
                 },
             ]
         }
+
+        if sg_uf:
+            query["$and"].append(self._uf_clause(sg_uf))
 
         if bairro:
             query = {
@@ -608,7 +632,7 @@ class MongoTerritorialAggregationRepository(
         self,
         *,
         co_municipio: str,
-        sg_uf: str | None,
+        sg_uf: str | list[str] | None,
     ) -> list[dict[str, Any]]:
         match_conditions: list[dict[str, Any]] = [
             {
@@ -619,15 +643,7 @@ class MongoTerritorialAggregationRepository(
             }
         ]
         if sg_uf:
-            match_conditions.append(
-                {
-                    "$or": [
-                        {"sg_uf": sg_uf},
-                        {"uf": sg_uf},
-                        {"estado_sigla": sg_uf},
-                    ]
-                }
-            )
+            match_conditions.append(self._uf_clause(sg_uf))
 
         pipeline = [
             {"$match": {"$and": match_conditions}},
@@ -760,21 +776,32 @@ class MongoTerritorialAggregationRepository(
         *,
         co_municipio: str,
         bairro: str | None,
+        sg_uf: str | list[str] | None = None,
     ) -> list[dict[str, Any]]:
         municipio_match_values: list[Any] = [co_municipio]
         if co_municipio.isdigit():
             municipio_match_values.append(int(co_municipio))
 
+        match_conditions: list[dict[str, Any]] = [
+            {
+                "$or": [
+                    {"co_municipio": {"$in": municipio_match_values}},
+                    {"municipioIdIbge": {"$in": municipio_match_values}},
+                    {"municipio_id_ibge": {"$in": municipio_match_values}},
+                    {"idIbge": {"$in": municipio_match_values}},
+                ]
+            }
+        ]
+        if sg_uf:
+            match_conditions.append(self._uf_clause(sg_uf))
+
         pipeline = [
             {
-                "$match": {
-                    "$or": [
-                        {"co_municipio": {"$in": municipio_match_values}},
-                        {"municipioIdIbge": {"$in": municipio_match_values}},
-                        {"municipio_id_ibge": {"$in": municipio_match_values}},
-                        {"idIbge": {"$in": municipio_match_values}},
-                    ]
-                }
+                "$match": (
+                    match_conditions[0]
+                    if len(match_conditions) == 1
+                    else {"$and": match_conditions}
+                )
             },
             {
                 "$project": {

--- a/tests/test_mongo_territorial_aggregation_repository.py
+++ b/tests/test_mongo_territorial_aggregation_repository.py
@@ -195,6 +195,52 @@ async def test_get_cities_filters_list_by_sg_uf():
 
 
 @pytest.mark.asyncio
+async def test_get_cities_filters_by_multiple_ufs():
+    municipio_collection = FakeCollection(find_docs=[])
+    repository = MongoTerritorialAggregationRepository(
+        municipio_collection=municipio_collection,
+        bairro_collection=FakeCollection(),
+        setor_collection=FakeCollection(),
+    )
+
+    await repository.get_cities(sg_uf=["pb", " PE ", "pb"])
+
+    assert municipio_collection.last_find_query == {
+        "$or": [
+            {"sg_uf": {"$in": ["PB", "PE"]}},
+            {"uf": {"$in": ["PB", "PE"]}},
+            {"estado_sigla": {"$in": ["PB", "PE"]}},
+        ]
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_by_municipio_filters_primary_and_fallback_by_multiple_ufs():
+    bairro_collection = FakeCollection(find_docs=[])
+    setor_collection = FakeCollection()
+    repository = MongoTerritorialAggregationRepository(
+        municipio_collection=FakeCollection(),
+        bairro_collection=bairro_collection,
+        setor_collection=setor_collection,
+    )
+
+    await repository.get_by_municipio(
+        municipio_id_ibge="2507507",
+        sg_uf=["pb", "pe"],
+    )
+
+    uf_clause = {
+        "$or": [
+            {"sg_uf": {"$in": ["PB", "PE"]}},
+            {"uf": {"$in": ["PB", "PE"]}},
+            {"estado_sigla": {"$in": ["PB", "PE"]}},
+        ]
+    }
+    assert uf_clause in bairro_collection.last_find_query["$and"]
+    assert uf_clause in setor_collection.last_aggregate_pipeline[0]["$match"]["$and"]
+
+
+@pytest.mark.asyncio
 async def test_get_by_municipio_returns_primary_bairro_collection():
     municipio_collection = FakeCollection()
     bairro_collection = FakeCollection(

--- a/tests/unit/application/aggregation/test_aggregation_uf_filter.py
+++ b/tests/unit/application/aggregation/test_aggregation_uf_filter.py
@@ -1,0 +1,42 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.application.aggregation.get_city_aggregations import GetCityAggregations
+from src.application.aggregation.get_neighborhood_aggregations import (
+    GetNeighborhoodAggregations,
+)
+
+
+@pytest.mark.asyncio
+async def test_city_use_case_passes_multiple_ufs_to_repository():
+    repository = AsyncMock()
+    repository.get_cities.return_value = {"type": "FeatureCollection", "features": []}
+    use_case = GetCityAggregations(repository)
+
+    await use_case.execute(sg_uf=["PB", "PE"])
+
+    repository.get_cities.assert_awaited_once_with(
+        co_municipio=None,
+        sg_uf=["PB", "PE"],
+        include_geometria=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_neighborhood_use_case_passes_multiple_ufs_to_repository():
+    repository = AsyncMock()
+    repository.get_by_municipio.return_value = []
+    use_case = GetNeighborhoodAggregations(repository)
+
+    await use_case.execute(
+        municipio_id_ibge="2507507",
+        sg_uf=["PB", "PE"],
+    )
+
+    repository.get_by_municipio.assert_awaited_once_with(
+        municipio_id_ibge="2507507",
+        bairro=None,
+        sg_uf=["PB", "PE"],
+        include_geometria=False,
+    )


### PR DESCRIPTION
## Descrição

Atualiza os casos de uso de agregação de cidades e bairros para suportarem uma lista de UFs por meio do parâmetro `sg_uf`.

O filtro é propagado até o repositório e aplicado nas consultas ao MongoDB utilizando `$in` quando múltiplas UFs são fornecidas.

## Alterações

- Adicionado suporte a `str | list[str] | None` no filtro `sg_uf`.
- Propagado o filtro de UF nos casos de uso de cidades e bairros.
- Normalizadas as UFs recebidas, removendo espaços, convertendo para maiúsculas e eliminando duplicações.
- Aplicado o filtro nas consultas principais e nos fallbacks de agregação.
- Mantido o comportamento existente quando nenhuma UF é fornecida.
- Adicionados testes para o repasse e a aplicação do filtro multi-UF.

## Arquivos adicionais

Embora a task destaque os dois casos de uso, também foi necessário atualizar o contrato e a implementação do repositório para garantir que a lista de UFs seja efetivamente aplicada nas consultas ao MongoDB, conforme o critério de aceite.

## Validação

- 77 testes passaram.
- Ruff passou nos arquivos alterados.
- Nenhum comentário foi adicionado ao código.

## Dependência

- ODIN-B01
