### PR TITLE
feat: adiciona parametro opcional estado_sigla na busca universal

### DIFF
--- a/src/presentation/http/controller/search/universal_search_controller.py
+++ b/src/presentation/http/controller/search/universal_search_controller.py
@@ -38,13 +38,16 @@ async def universal_search(
         ..., min_length=2, description="Texto de busca (mínimo 2 caracteres)"
     ),
     sg_uf: str | None = Query(None, description="Filtrar por UF"),
+    estado_sigla: str | None = Query(None, description="Filtrar por estado (ex: PB, PE)"),
     municipio_id: str | None = Query(None, description="Restringir a um município"),
     limit: int = Query(20, ge=1, le=20, description="Máximo de sugestões retornadas"),
     use_case: UniversalSearchUseCase = Depends(get_universal_search_use_case),
 ):
+    uf_filter = estado_sigla if estado_sigla else sg_uf
+
     dto = UniversalSearchInputDTO(
         q=q.strip(),
-        sg_uf=sg_uf,
+        sg_uf=uf_filter,
         municipio_id=municipio_id,
         limit=limit,
     )
@@ -66,3 +69,4 @@ async def universal_search(
         total=result.total,
         query=result.query,
     )
+


### PR DESCRIPTION
## What does this PR do?

Este PR implementa a adição do parâmetro opcional estado_sigla na busca universal, permitindo diferenciar resultados homônimos entre estados diferentes (ex: "São José" em PB e PE) diretamente pelo endpoint, sem quebrar requisições legadas.

Arquivos modificados e métodos utilizados:

src/presentation/http/controller/search/universal_search_controller.py`
    Método: Adição do parâmetro `estado_sigla` via `Query` do FastAPI (opcional, padrão `None`). O valor recebido é injetado diretamente no DTO de entrada através da variável `sg_uf`, aproveitando a estrutura de filtragem que já existia na camada de Aplicação e Domínio (Repositório).
    Resultado: Risco zero de quebra da lógica original. O Swagger agora documenta corretamente o filtro e os resultados refletem a segregação por UF quando o parâmetro é passado, mantendo o escopo nacional caso seja ignorado.

## Task link in GitHub Issues:

Fixes #NÚMERO_DA_SUA_TASK

## Quality Checklist

- [x] My code follows the best practices and architecture defined for the project.
- [x] I have tested my changes locally and they work as expected.