### PR TITLE
feat: implementa resumo agregado por estado

### DIFF
--- a/RELATORIO_BACKEND.md
+++ b/RELATORIO_BACKEND.md
@@ -359,7 +359,7 @@ Todos os endpoints estão sob o prefixo **`/api/v1`**.
 | **Descrição** | Resumo estadual com indicadores educacionais e socioeconômicos agregados de todos os municípios |
 | **Collection** | `municipio_indicadores` |
 | **Parâmetros Path** | `sg_uf` (2 chars, ex: PB) |
-| **Resposta** | `StateSummary` com: `sg_uf`, `estado`, `educacao` (30+ indicadores com médias ponderadas), `socioeconomico` (população total, taxa desemprego média) |
+| **Resposta** | `StateSummary` com: `sg_uf`, `estado`, `total_municipios`, `educacao` (30+ indicadores com médias ponderadas), `socioeconomico` (população total, taxa desemprego média) |
 | **Cálculo educação** | Infraestrutura: média ponderada por nº de escolas. Indicadores acadêmicos: média ponderada por nº de alunos |
 | **Cálculo socioeconômico** | Média ponderada por população |
 | **Erro** | 404 se não houver dados para o estado |

--- a/src/application/state/get_state_summary/get_state_summary.py
+++ b/src/application/state/get_state_summary/get_state_summary.py
@@ -8,7 +8,8 @@ class GetStateSummaryUseCase:
         self.state_repository = state_repository
 
     async def execute(self, sg_uf: str) -> StateSummary | None:
-        cities = await self.state_repository.get_cities_data_by_state(sg_uf)
+        normalized_sg_uf = sg_uf.strip().upper()
+        cities = await self.state_repository.get_cities_data_by_state(normalized_sg_uf)
         if not cities:
             return None
-        return StateSummaryFactory.create_from_cities(sg_uf, cities)
+        return StateSummaryFactory.create_from_cities(normalized_sg_uf, cities)

--- a/src/domain/entities/state.py
+++ b/src/domain/entities/state.py
@@ -1,5 +1,39 @@
 from pydantic import BaseModel
 
+ESTADOS_BRASIL = {
+    "AC": "Acre",
+    "AL": "Alagoas",
+    "AP": "Amapá",
+    "AM": "Amazonas",
+    "BA": "Bahia",
+    "CE": "Ceará",
+    "DF": "Distrito Federal",
+    "ES": "Espírito Santo",
+    "GO": "Goiás",
+    "MA": "Maranhão",
+    "MT": "Mato Grosso",
+    "MS": "Mato Grosso do Sul",
+    "MG": "Minas Gerais",
+    "PA": "Pará",
+    "PB": "Paraíba",
+    "PR": "Paraná",
+    "PE": "Pernambuco",
+    "PI": "Piauí",
+    "RJ": "Rio de Janeiro",
+    "RN": "Rio Grande do Norte",
+    "RS": "Rio Grande do Sul",
+    "RO": "Rondônia",
+    "RR": "Roraima",
+    "SC": "Santa Catarina",
+    "SP": "São Paulo",
+    "SE": "Sergipe",
+    "TO": "Tocantins",
+}
+
+
+def get_state_name(sg_uf: str) -> str | None:
+    return ESTADOS_BRASIL.get(sg_uf.strip().upper())
+
 
 class State(BaseModel):
     id: str

--- a/src/domain/entities/state_summary.py
+++ b/src/domain/entities/state_summary.py
@@ -67,5 +67,9 @@ class StateSummary(BaseModel):
 
     sg_uf: str = Field(..., description="Sigla da Unidade Federativa (ex: PB)")
     estado: str | None = Field(default=None, description="Nome completo do estado")
+    total_municipios: int = Field(
+        default=0,
+        description="Total de municípios considerados na agregação",
+    )
     educacao: EducacaoStateStats
     socioeconomico: SocioeconomicoStateStats

--- a/src/domain/factories/state_summary_factory.py
+++ b/src/domain/factories/state_summary_factory.py
@@ -1,6 +1,7 @@
 from typing import List
 
 from src.domain.entities.city_aggregation import CityAggregation
+from src.domain.entities.state import get_state_name
 from src.domain.entities.state_summary import (
     EducacaoStateStats,
     SocioeconomicoStateStats,
@@ -130,8 +131,11 @@ class StateSummaryFactory:
         cls, sg_uf: str, cities: List[CityAggregation]
     ) -> StateSummary:
         """Método público que constrói o objeto final."""
+        normalized_sg_uf = sg_uf.strip().upper()
         return StateSummary(
-            sg_uf=sg_uf.upper(),
+            sg_uf=normalized_sg_uf,
+            estado=get_state_name(normalized_sg_uf),
+            total_municipios=len(cities),
             educacao=cls._calc_educacao(cities),
             socioeconomico=cls._calc_socioeconomico(cities),
         )

--- a/src/infrastructure/database/mapper/state_mapper.py
+++ b/src/infrastructure/database/mapper/state_mapper.py
@@ -1,39 +1,9 @@
-from src.domain.entities.state import State
-
-ESTADOS_BRASIL = {
-    "AC": "Acre",
-    "AL": "Alagoas",
-    "AP": "Amapá",
-    "AM": "Amazonas",
-    "BA": "Bahia",
-    "CE": "Ceará",
-    "DF": "Distrito Federal",
-    "ES": "Espírito Santo",
-    "GO": "Goiás",
-    "MA": "Maranhão",
-    "MT": "Mato Grosso",
-    "MS": "Mato Grosso do Sul",
-    "MG": "Minas Gerais",
-    "PA": "Pará",
-    "PB": "Paraíba",
-    "PR": "Paraná",
-    "PE": "Pernambuco",
-    "PI": "Piauí",
-    "RJ": "Rio de Janeiro",
-    "RN": "Rio Grande do Norte",
-    "RS": "Rio Grande do Sul",
-    "RO": "Rondônia",
-    "RR": "Roraima",
-    "SC": "Santa Catarina",
-    "SP": "São Paulo",
-    "SE": "Sergipe",
-    "TO": "Tocantins",
-}
+from src.domain.entities.state import State, get_state_name
 
 
 class StateMapper:
     @staticmethod
     def to_entity(sg_uf: str) -> State:
         sigla = sg_uf.upper()
-        nome = ESTADOS_BRASIL.get(sigla, "Desconhecido")
+        nome = get_state_name(sigla) or "Desconhecido"
         return State(id=sigla, nome=nome, sigla=sigla)

--- a/src/infrastructure/database/mapper/state_summary_mapper.py
+++ b/src/infrastructure/database/mapper/state_summary_mapper.py
@@ -63,7 +63,10 @@ class StateSummaryMapper:
                 ideb_iniciais=cls._extract_number(
                     educacao.get("mediaIdebAnosIniciais")
                 ),
-                ideb_finais=cls._extract_number(educacao.get("mediaIdebAnosFinals")),
+                ideb_finais=cls._extract_number(
+                    educacao.get("mediaIdebAnosFinals")
+                    or educacao.get("mediaIdebAnosFinais")
+                ),
                 ideb_ensino_medio=cls._extract_number(
                     educacao.get("mediaIdebEnsinoMedio")
                 ),

--- a/src/presentation/http/controller/state/get_state_summary_controller.py
+++ b/src/presentation/http/controller/state/get_state_summary_controller.py
@@ -1,30 +1,30 @@
-from dependency_injector.wiring import Provide, inject
 from fastapi import APIRouter, Depends, HTTPException, Path
 
 from src.application.state.get_state_summary.get_state_summary import (
     GetStateSummaryUseCase,
 )
 from src.domain.entities.state_summary import StateSummary
-from src.presentation.http.controller.state.container import Container
+from src.presentation.http.controller.state.container import container
 
 router = APIRouter()
 
 
+def get_use_case() -> GetStateSummaryUseCase:
+    return container.get_state_summary_use_case()
+
+
 @router.get("/estados/{sg_uf}/resumo", response_model=StateSummary)
-@inject
 async def get_state_summary(
     sg_uf: str = Path(
         ...,
         min_length=2,
         max_length=2,
         description="Sigla da Unidade Federativa (ex: PB)",
-        example="PB",
+        examples=["PB"],
     ),
-    use_case: GetStateSummaryUseCase = Depends(
-        Provide[Container.get_state_summary_use_case]
-    ),
+    use_case: GetStateSummaryUseCase = Depends(get_use_case),
 ):
-    result = await use_case.execute(sg_uf.upper())
+    result = await use_case.execute(sg_uf)
 
     if not result:
         raise HTTPException(

--- a/tests/test_state_summary_route.py
+++ b/tests/test_state_summary_route.py
@@ -1,0 +1,133 @@
+import httpx
+import pytest
+
+from src.domain.entities.state_summary import (
+    EducacaoStateStats,
+    SocioeconomicoStateStats,
+    StateSummary,
+)
+from src.main import app
+from src.presentation.http.controller.state.get_state_summary_controller import (
+    get_use_case,
+)
+
+
+class FakeGetStateSummaryUseCase:
+    def __init__(self, result: StateSummary | None):
+        self.result = result
+        self.received_sg_uf: str | None = None
+
+    async def execute(self, sg_uf: str) -> StateSummary | None:
+        self.received_sg_uf = sg_uf
+        return self.result
+
+
+@pytest.fixture(autouse=True)
+def clear_dependency_overrides():
+    yield
+    app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_state_summary_route_returns_paraiba_aggregates():
+    summary = StateSummary(
+        sg_uf="PB",
+        estado="Paraíba",
+        total_municipios=223,
+        educacao=EducacaoStateStats(
+            total_escolas=3200,
+            total_alunos=650000,
+            avg_ideb_iniciais=5.1,
+        ),
+        socioeconomico=SocioeconomicoStateStats(
+            populacao_total=3974495,
+            indicadores={"taxa_desemprego_media": 8.4},
+        ),
+    )
+    fake_use_case = FakeGetStateSummaryUseCase(summary)
+    app.dependency_overrides[get_use_case] = lambda: fake_use_case
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/api/v1/estados/PB/resumo")
+
+    assert response.status_code == 200
+    assert fake_use_case.received_sg_uf == "PB"
+    assert response.json() == {
+        "sg_uf": "PB",
+        "estado": "Paraíba",
+        "total_municipios": 223,
+        "educacao": {
+            "metodo_agregacao": "soma_absoluta",
+            "total_escolas": 3200,
+            "total_alunos": 650000,
+            "pct_com_biblioteca": None,
+            "pct_com_internet": None,
+            "pct_com_internet_alunos": None,
+            "pct_com_lab_informatica": None,
+            "pct_com_lab_ciencias": None,
+            "pct_sem_acessibilidade": None,
+            "pct_com_agua_potavel": None,
+            "pct_com_energia_publica": None,
+            "pct_com_esgoto_rede_publica": None,
+            "pct_com_coleta_lixo": None,
+            "pct_com_quadra_esportes": None,
+            "pct_com_cozinha": None,
+            "pct_com_refeitorio": None,
+            "avg_ideb_iniciais": 5.1,
+            "avg_ideb_finais": None,
+            "avg_ideb_ensino_medio": None,
+            "avg_afd_anos_iniciais": None,
+            "avg_afd_anos_finais": None,
+            "avg_afd_ensino_medio": None,
+            "avg_tdi_anos_iniciais": None,
+            "avg_tdi_anos_finais": None,
+            "avg_tdi_ensino_medio": None,
+            "avg_taxa_aprovacao_ai": None,
+            "avg_taxa_aprovacao_af": None,
+            "avg_taxa_aprovacao_em": None,
+            "avg_taxa_abandono_ai": None,
+            "avg_taxa_abandono_af": None,
+            "avg_taxa_abandono_em": None,
+            "avg_docentes_superior_ai": None,
+            "avg_docentes_superior_af": None,
+            "avg_docentes_superior_em": None,
+            "avg_horas_aula_ai": None,
+            "avg_horas_aula_af": None,
+            "avg_horas_aula_em": None,
+            "avg_alunos_turma_ai": None,
+            "avg_alunos_turma_af": None,
+            "avg_alunos_turma_em": None,
+        },
+        "socioeconomico": {
+            "metodo_agregacao": "media_ponderada",
+            "populacao_total": 3974495,
+            "indicadores": {"taxa_desemprego_media": 8.4},
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_state_summary_route_returns_404_when_state_has_no_data():
+    app.dependency_overrides[get_use_case] = lambda: FakeGetStateSummaryUseCase(None)
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/api/v1/estados/ZZ/resumo")
+
+    assert response.status_code == 404
+    assert response.json() == {
+        "error": "NOT_FOUND",
+        "message": "Dados não encontrados para o estado: ZZ",
+    }
+
+
+@pytest.mark.asyncio
+async def test_state_summary_route_rejects_invalid_uf_length():
+    app.dependency_overrides[get_use_case] = lambda: FakeGetStateSummaryUseCase(None)
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/api/v1/estados/P/resumo")
+
+    assert response.status_code == 422

--- a/tests/unit/application/state/test_get_state_summary.py
+++ b/tests/unit/application/state/test_get_state_summary.py
@@ -1,32 +1,71 @@
-import pytest
 from unittest.mock import AsyncMock
-from src.application.state.get_state_summary.get_state_summary import GetStateSummaryUseCase
-from src.domain.entities.city_aggregation import CityAggregation, CityEducacao, CitySocioeconomico
+
+import pytest
+
+from src.application.state.get_state_summary.get_state_summary import (
+    GetStateSummaryUseCase,
+)
+from src.domain.entities.city_aggregation import (
+    CityAggregation,
+    CityEducacao,
+    CitySocioeconomico,
+)
+
 
 @pytest.mark.asyncio
 async def test_get_state_summary_success():
-  
     mock_repo = AsyncMock()
-    
+
     mock_repo.get_cities_data_by_state.return_value = [
         CityAggregation(
-            educacao=CityEducacao(total_escolas=10, total_alunos=100, pct_com_biblioteca=50.0, pct_com_internet=100.0, pct_com_lab_informatica=0.0, pct_sem_acessibilidade=0.0, ideb_iniciais=5.0, ideb_finais=0.0),
-            socioeconomico=CitySocioeconomico(populacao=1000, taxa_desemprego=10.0)
+            educacao=CityEducacao(
+                total_escolas=10,
+                total_alunos=100,
+                pct_com_biblioteca=50.0,
+                pct_com_internet=100.0,
+                pct_com_lab_informatica=0.0,
+                pct_sem_acessibilidade=0.0,
+                ideb_iniciais=5.0,
+                ideb_finais=0.0,
+            ),
+            socioeconomico=CitySocioeconomico(populacao=1000, taxa_desemprego=10.0),
         ),
         CityAggregation(
-            educacao=CityEducacao(total_escolas=10, total_alunos=100, pct_com_biblioteca=50.0, pct_com_internet=0.0, pct_com_lab_informatica=0.0, pct_sem_acessibilidade=0.0, ideb_iniciais=6.0, ideb_finais=0.0),
-            socioeconomico=CitySocioeconomico(populacao=3000, taxa_desemprego=2.0)
-        )
+            educacao=CityEducacao(
+                total_escolas=10,
+                total_alunos=100,
+                pct_com_biblioteca=50.0,
+                pct_com_internet=0.0,
+                pct_com_lab_informatica=0.0,
+                pct_sem_acessibilidade=0.0,
+                ideb_iniciais=6.0,
+                ideb_finais=0.0,
+            ),
+            socioeconomico=CitySocioeconomico(populacao=3000, taxa_desemprego=2.0),
+        ),
     ]
 
     use_case = GetStateSummaryUseCase(mock_repo)
-    result = await use_case.execute("PB")
+    result = await use_case.execute(" pb ")
 
-  
     assert result is not None
     assert result.sg_uf == "PB"
+    assert result.estado == "Paraíba"
+    assert result.total_municipios == 2
     assert result.educacao.total_escolas == 20
-    assert result.educacao.pct_com_biblioteca == 50.0 
+    assert result.educacao.total_alunos == 200
+    assert result.educacao.pct_com_biblioteca == 50.0
     assert result.educacao.avg_ideb_iniciais == 5.5
     assert result.socioeconomico.indicadores is not None
     assert result.socioeconomico.indicadores["taxa_desemprego_media"] == 4.0
+    mock_repo.get_cities_data_by_state.assert_awaited_once_with("PB")
+
+
+@pytest.mark.asyncio
+async def test_get_state_summary_returns_none_when_state_has_no_data():
+    mock_repo = AsyncMock()
+    mock_repo.get_cities_data_by_state.return_value = []
+
+    use_case = GetStateSummaryUseCase(mock_repo)
+
+    assert await use_case.execute("PE") is None


### PR DESCRIPTION

## Descrição

Implementa o endpoint de resumo estadual, retornando dados educacionais e socioeconômicos agregados por UF.

## Endpoint

```http
GET /api/v1/estados/{sg_uf}/resumo
```

Teste local:

```text
http://localhost:8000/api/v1/estados/PB/resumo
```

## Alterações

- Total de municípios, escolas e alunos;
- Médias do IDEB e demais indicadores educacionais;
- Indicadores socioeconômicos;
- Identificação e normalização da UF;
- Tratamento de estado sem dados;
- Testes unitários e de integração.

## Evidências:

<img width="1432" height="863" alt="image" src="https://github.com/user-attachments/assets/1a1d5d1d-5890-4bfd-bd6e-d494d7c7e2d8" />

<img width="1437" height="867" alt="image" src="https://github.com/user-attachments/assets/782545fe-dc71-4fdd-b891-1eef6af7ba9e" />

## Validação

- [x] Critério de aceite validado para `PB`;
- [x] Testes da funcionalidade: `5 passed`;
- [x] Suíte completa: `81 passed`;
- [x] Lint dos arquivos alterados aprovado.