### PR TITLE
Task/odin b06 state filter aggregations

### DIFF
--- a/src/presentation/http/controller/aggregation/aggregations_controller.py
+++ b/src/presentation/http/controller/aggregation/aggregations_controller.py
@@ -1,6 +1,7 @@
-from typing import Any
+from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import StringConstraints
 
 from src.application.aggregation.get_city_aggregations import GetCityAggregations
 from src.application.aggregation.get_neighborhood_aggregations import (
@@ -17,6 +18,16 @@ from src.presentation.http.schemas.aggregation_schema import (
 )
 
 router = APIRouter()
+
+UFCode = Annotated[
+    str,
+    StringConstraints(
+        strip_whitespace=True,
+        to_upper=True,
+        min_length=2,
+        max_length=2,
+    ),
+]
 
 
 def _to_neighborhood_feature_collection(
@@ -108,11 +119,13 @@ async def get_city_aggregations(
         max_length=7,
         description="IBGE municipality code (7 digits). Primary data source: municipio_indicadores. Fallback to setor_indicadores if not found.",
     ),
-    sg_uf: str | None = Query(
+    sg_uf: list[UFCode] | None = Query(
         default=None,
-        min_length=2,
-        max_length=2,
-        description="Optional UF filter (e.g., PB). Applied when listing cities and combined with municipioIdIbge when provided.",
+        description=(
+            "Optional UF filter. Repeat the query parameter to filter multiple "
+            "states (for example, `?sg_uf=PB&sg_uf=PE`). When omitted, "
+            "aggregations from all states are returned."
+        ),
     ),
     include_geometria: bool = Query(
         default=False,
@@ -122,7 +135,7 @@ async def get_city_aggregations(
 ):
     return await use_case.execute(
         co_municipio=municipioIdIbge,
-        sg_uf=sg_uf.upper() if sg_uf else None,
+        sg_uf=sg_uf,
         include_geometria=include_geometria,
     )
 
@@ -158,6 +171,14 @@ async def get_neighborhood_aggregations(
         min_length=1,
         description="Optional neighborhood filter. Matches bairro, nm_bairro and nome_area.",
     ),
+    sg_uf: list[UFCode] | None = Query(
+        default=None,
+        description=(
+            "Optional UF filter. Repeat the query parameter to filter multiple "
+            "states (for example, `?sg_uf=PB&sg_uf=PE`). When omitted, no UF "
+            "filter is applied."
+        ),
+    ),
     include_geometria: bool = Query(
         default=False,
         description="If true, returns full geometria (MultiPolygon/Point). Default false to reduce payload size.",
@@ -176,6 +197,7 @@ async def get_neighborhood_aggregations(
     result = await use_case.execute(
         municipio_id_ibge=resolved_municipio_id,
         bairro=bairro,
+        sg_uf=sg_uf,
         include_geometria=include_geometria,
     )
 

--- a/tests/test_aggregation_route.py
+++ b/tests/test_aggregation_route.py
@@ -9,30 +9,46 @@ from src.presentation.http.controller.aggregation.callable.aggregation_callable 
 
 
 class FakeGetCityAggregationsUseCase:
+    def __init__(self):
+        self.received_sg_uf: list[str] | None = None
+
     async def execute(
         self,
         co_municipio: str | None = None,
-        sg_uf: str | None = None,
+        sg_uf: list[str] | None = None,
         include_geometria: bool = False,
     ):
-        source = "setor_indicadores" if co_municipio == "2507507" else "municipio_indicadores"
-        resolved_uf = sg_uf or "PB"
+        self.received_sg_uf = sg_uf
+        source = (
+            "setor_indicadores"
+            if co_municipio == "2507507"
+            else "municipio_indicadores"
+        )
+        resolved_ufs = sg_uf or ["PB"]
         geometry = {"type": "Point", "coordinates": [-34.86, -7.12]}
         if include_geometria:
             geometry = {
                 "type": "Polygon",
-                "coordinates": [[[-34.9, -7.2], [-34.8, -7.2], [-34.8, -7.1], [-34.9, -7.1], [-34.9, -7.2]]],
+                "coordinates": [
+                    [
+                        [-34.9, -7.2],
+                        [-34.8, -7.2],
+                        [-34.8, -7.1],
+                        [-34.9, -7.1],
+                        [-34.9, -7.2],
+                    ]
+                ],
             }
         return {
             "type": "FeatureCollection",
             "features": [
                 {
                     "type": "Feature",
-                    "id": co_municipio or "2507507",
+                    "id": co_municipio or str(2507507 + index),
                     "geometry": geometry,
                     "properties": {
-                        "municipioIdIbge": co_municipio or "2507507",
-                        "co_municipio": co_municipio or "2507507",
+                        "municipioIdIbge": co_municipio or str(2507507 + index),
+                        "co_municipio": co_municipio or str(2507507 + index),
                         "municipio": "Joao Pessoa",
                         "uf": resolved_uf,
                         "total_escolas": 123,
@@ -46,17 +62,23 @@ class FakeGetCityAggregationsUseCase:
                         "source": source,
                     },
                 }
+                for index, resolved_uf in enumerate(resolved_ufs)
             ],
         }
 
 
 class FakeGetNeighborhoodAggregationsUseCase:
+    def __init__(self):
+        self.received_sg_uf: list[str] | None = None
+
     async def execute(
         self,
         municipio_id_ibge: str,
         bairro: str | None = None,
         include_geometria: bool = False,
+        sg_uf: list[str] | None = None,
     ):
+        self.received_sg_uf = sg_uf
         resolved_bairro = bairro or "Area Urbana Integrada"
         return [
             {
@@ -95,7 +117,9 @@ class FakeGetNeighborhoodAggregationsUseCase:
 
 
 @pytest.mark.asyncio
-async def test_get_city_aggregations_route_returns_200_and_feature_collection(monkeypatch):
+async def test_get_city_aggregations_route_returns_200_and_feature_collection(
+    monkeypatch,
+):
     async def fake_connect():
         return True
 
@@ -106,13 +130,14 @@ async def test_get_city_aggregations_route_returns_200_and_feature_collection(mo
 
     monkeypatch.setattr(mongodb, "connect", fake_connect)
     monkeypatch.setattr(mongodb, "disconnect", fake_disconnect)
-    app.dependency_overrides[get_city_aggregations_use_case] = (
-        lambda: FakeGetCityAggregationsUseCase()
-    )
+    fake_use_case = FakeGetCityAggregationsUseCase()
+    app.dependency_overrides[get_city_aggregations_use_case] = lambda: fake_use_case
 
     transport = httpx.ASGITransport(app=app)
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
-        response = await client.get("/api/v1/aggregations/cities?municipioIdIbge=2507507")
+        response = await client.get(
+            "/api/v1/aggregations/cities?municipioIdIbge=2507507"
+        )
 
     app.dependency_overrides.clear()
 
@@ -121,7 +146,10 @@ async def test_get_city_aggregations_route_returns_200_and_feature_collection(mo
     assert payload["type"] == "FeatureCollection"
     assert payload["features"][0]["properties"]["source"] == "setor_indicadores"
     assert payload["features"][0]["geometry"]["coordinates"] == [-34.86, -7.12]
-    assert payload["features"][0]["properties"]["socioeconomico"]["anoReferencia"] == 2022
+    assert (
+        payload["features"][0]["properties"]["socioeconomico"]["anoReferencia"] == 2022
+    )
+    assert fake_use_case.received_sg_uf is None
 
 
 @pytest.mark.asyncio
@@ -136,13 +164,16 @@ async def test_get_neighborhood_aggregations_route_returns_200(monkeypatch):
 
     monkeypatch.setattr(mongodb, "connect", fake_connect)
     monkeypatch.setattr(mongodb, "disconnect", fake_disconnect)
+    fake_use_case = FakeGetNeighborhoodAggregationsUseCase()
     app.dependency_overrides[get_neighborhood_aggregations_use_case] = (
-        lambda: FakeGetNeighborhoodAggregationsUseCase()
+        lambda: fake_use_case
     )
 
     transport = httpx.ASGITransport(app=app)
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
-        response = await client.get("/api/v1/aggregations/neighborhoods?municipio_id=2507507")
+        response = await client.get(
+            "/api/v1/aggregations/neighborhoods?municipio_id=2507507"
+        )
 
     app.dependency_overrides.clear()
 
@@ -157,6 +188,7 @@ async def test_get_neighborhood_aggregations_route_returns_200(monkeypatch):
     assert payload[0]["socioeconomico"]["anoReferencia"] == 2022
     assert payload[0]["educacao"]["totalMatriculas"] == 4500
     assert payload[0]["source"] == "bairros_indicadores"
+    assert fake_use_case.received_sg_uf is None
 
 
 @pytest.mark.asyncio
@@ -189,7 +221,9 @@ async def test_get_neighborhood_aggregations_route_can_include_geometria(monkeyp
     assert payload["features"][0]["geometry"]["type"] == "Point"
     assert payload["features"][0]["properties"]["tem_bairro_oficial"] is False
     assert payload["features"][0]["properties"]["nivel"] == "bairro"
-    assert payload["features"][0]["properties"]["socioeconomico"]["anoReferencia"] == 2022
+    assert (
+        payload["features"][0]["properties"]["socioeconomico"]["anoReferencia"] == 2022
+    )
     assert payload["features"][0]["properties"]["educacao"]["totalMatriculas"] == 4500
 
 
@@ -205,9 +239,8 @@ async def test_get_city_aggregations_route_accepts_sg_uf_filter(monkeypatch):
 
     monkeypatch.setattr(mongodb, "connect", fake_connect)
     monkeypatch.setattr(mongodb, "disconnect", fake_disconnect)
-    app.dependency_overrides[get_city_aggregations_use_case] = (
-        lambda: FakeGetCityAggregationsUseCase()
-    )
+    fake_use_case = FakeGetCityAggregationsUseCase()
+    app.dependency_overrides[get_city_aggregations_use_case] = lambda: fake_use_case
 
     transport = httpx.ASGITransport(app=app)
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
@@ -218,6 +251,117 @@ async def test_get_city_aggregations_route_accepts_sg_uf_filter(monkeypatch):
     assert response.status_code == 200
     payload = response.json()
     assert payload["features"][0]["properties"]["uf"] == "PB"
+    assert fake_use_case.received_sg_uf == ["PB"]
+
+
+@pytest.mark.asyncio
+async def test_get_city_aggregations_route_accepts_multiple_sg_uf_filters(monkeypatch):
+    async def fake_connect():
+        return True
+
+    async def fake_disconnect():
+        return None
+
+    from src.infrastructure.database.config.connect_db import mongodb
+
+    monkeypatch.setattr(mongodb, "connect", fake_connect)
+    monkeypatch.setattr(mongodb, "disconnect", fake_disconnect)
+    fake_use_case = FakeGetCityAggregationsUseCase()
+    app.dependency_overrides[get_city_aggregations_use_case] = lambda: fake_use_case
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/api/v1/aggregations/cities?sg_uf=pb&sg_uf=PE")
+
+    app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    assert fake_use_case.received_sg_uf == ["PB", "PE"]
+    payload = response.json()
+    assert {feature["properties"]["uf"] for feature in payload["features"]} == {
+        "PB",
+        "PE",
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_neighborhood_aggregations_route_accepts_multiple_sg_uf_filters(
+    monkeypatch,
+):
+    async def fake_connect():
+        return True
+
+    async def fake_disconnect():
+        return None
+
+    from src.infrastructure.database.config.connect_db import mongodb
+
+    monkeypatch.setattr(mongodb, "connect", fake_connect)
+    monkeypatch.setattr(mongodb, "disconnect", fake_disconnect)
+    fake_use_case = FakeGetNeighborhoodAggregationsUseCase()
+    app.dependency_overrides[get_neighborhood_aggregations_use_case] = (
+        lambda: fake_use_case
+    )
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get(
+            "/api/v1/aggregations/neighborhoods"
+            "?municipio_id=2507507&sg_uf=pb&sg_uf=PE"
+        )
+
+    app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    assert fake_use_case.received_sg_uf == ["PB", "PE"]
+
+
+@pytest.mark.asyncio
+async def test_aggregation_routes_reject_invalid_sg_uf_length(monkeypatch):
+    async def fake_connect():
+        return True
+
+    async def fake_disconnect():
+        return None
+
+    from src.infrastructure.database.config.connect_db import mongodb
+
+    monkeypatch.setattr(mongodb, "connect", fake_connect)
+    monkeypatch.setattr(mongodb, "disconnect", fake_disconnect)
+    app.dependency_overrides[get_city_aggregations_use_case] = (
+        lambda: FakeGetCityAggregationsUseCase()
+    )
+    app.dependency_overrides[get_neighborhood_aggregations_use_case] = (
+        lambda: FakeGetNeighborhoodAggregationsUseCase()
+    )
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        city_response = await client.get("/api/v1/aggregations/cities?sg_uf=P")
+        neighborhood_response = await client.get(
+            "/api/v1/aggregations/neighborhoods?municipio_id=2507507&sg_uf=PER"
+        )
+
+    app.dependency_overrides.clear()
+
+    assert city_response.status_code == 422
+    assert neighborhood_response.status_code == 422
+
+
+def test_aggregation_sg_uf_filters_are_documented_as_arrays_in_openapi():
+    schema = app.openapi()
+
+    for path in (
+        "/api/v1/aggregations/cities",
+        "/api/v1/aggregations/neighborhoods",
+    ):
+        parameters = schema["paths"][path]["get"]["parameters"]
+        sg_uf = next(
+            parameter for parameter in parameters if parameter["name"] == "sg_uf"
+        )
+
+        assert sg_uf["schema"]["anyOf"][0]["type"] == "array"
+        assert "?sg_uf=PB&sg_uf=PE" in sg_uf["description"]
 
 
 @pytest.mark.asyncio
@@ -238,7 +382,9 @@ async def test_get_city_aggregations_route_can_include_full_geometry(monkeypatch
 
     transport = httpx.ASGITransport(app=app)
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
-        response = await client.get("/api/v1/aggregations/cities?include_geometria=true")
+        response = await client.get(
+            "/api/v1/aggregations/cities?include_geometria=true"
+        )
 
     app.dependency_overrides.clear()
 


### PR DESCRIPTION
## 📌 Descrição

Implementa a **ODIN-B06**, adicionando suporte ao filtro por estado nos endpoints de agregações de cidades e bairros.

Os endpoints agora aceitam múltiplos valores de `sg_uf` pela repetição do query parameter:

```http
GET /api/v1/aggregations/cities?sg_uf=PB&sg_uf=PE
```

Quando `sg_uf` não é informado, a consulta continua retornando dados de todos os estados disponíveis.

## ✅ Alterações realizadas

- Adicionado suporte a múltiplos valores de `sg_uf` no endpoint de cidades.
- Adicionado o parâmetro `sg_uf` ao endpoint de bairros.
- Normalização automática das siglas para letras maiúsculas.
- Validação de exatamente dois caracteres para cada sigla.
- Encaminhamento da lista de estados para os casos de uso existentes.
- Documentação do comportamento na OpenAPI.
- Adição de testes para um estado, múltiplos estados, ausência do filtro, siglas inválidas e contrato OpenAPI.

## 🔗 Endpoints afetados

```http
GET /api/v1/aggregations/cities
GET /api/v1/aggregations/neighborhoods
```

### Exemplo para cidades

```http
GET /api/v1/aggregations/cities?sg_uf=PB&sg_uf=PE
```

### Exemplo para bairros

```http
GET /api/v1/aggregations/neighborhoods?municipio_id=2507507&sg_uf=PB&sg_uf=PE
```

## 🧪 Validação

- Suíte completa: **85 testes aprovados**
- Ruff lint: **aprovado**
- Ruff format: **aprovado**
- OpenAPI validada com `sg_uf` representado como uma lista de siglas.

## 📷 Evidências

### Consulta e resposta da API:

<img width="1181" height="663" alt="image" src="https://github.com/user-attachments/assets/ddb1b956-7058-4751-8432-b20313ce55c6" />

## ⚠️ Observação:


A validação end-to-end com dados reais de múltiplos estados permanece pendente, pois o banco disponível atualmente contém apenas dados da Paraíba:

- `municipio_indicadores`: somente PB;
- `setor_indicadores`: somente PB;
- `bairro_indicadores`: somente PB.

Por esse motivo, consultas com `sg_uf=PE` retornam uma coleção vazia. Será necessário repetir a validação após a disponibilização dos dados agregados de outros estados.


### Documentação no Swagger/OpenAPI

<img width="902" height="123" alt="image" src="https://github.com/user-attachments/assets/2464714a-efeb-4fc7-88b8-44fda596421e" />



## 🎯 Critério de aceite

A chamada abaixo aceita múltiplas UFs e retorna agregações das cidades pertencentes aos estados informados:

```http
GET /api/v1/aggregations/cities?sg_uf=PB&sg_uf=PE
```

## 🌿 Branches

- **Base:** `feat/Expansao_Nordeste`
- **Compare:** `task/odin-b06-state-filter-aggregations`
